### PR TITLE
feat: dashboard UX overhaul — Claude Console style

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -29,7 +29,7 @@ import Billing from './pages/cloud/Billing'
 import Team from './pages/cloud/Team'
 import AccountSettings from './pages/cloud/AccountSettings'
 import Users from './pages/cloud/Users'
-import Onboarding from './pages/cloud/Onboarding'
+// Onboarding merged into Home page
 
 function RequireLocal({ children }: { children: React.ReactNode }) {
   const mode = useModeStore(s => s.mode)
@@ -72,16 +72,7 @@ function RootRedirect() {
       setRedirect('/login')
       return
     }
-    const dismissed = localStorage.getItem('solon-onboarding-dismissed')
-    if (dismissed) {
-      setRedirect('/instances')
-      return
-    }
-    cloudAPI.getInstances().then(instances => {
-      setRedirect(instances.length === 0 ? '/onboarding' : '/instances')
-    }).catch(() => {
-      setRedirect('/instances')
-    })
+    setRedirect('/home')
   }, [mode, user])
 
   if (!redirect) return null
@@ -140,8 +131,10 @@ export default function App() {
       <Route element={<AppLayout />}>
         <Route path="/" element={<RootRedirect />} />
 
+        {/* Home — works in both local and cloud mode */}
+        <Route path="/home" element={<Home />} />
+
         {/* Local instance routes */}
-        <Route path="/home" element={<LocalRoute><Home /></LocalRoute>} />
         <Route path="/chat" element={<LocalRoute><Chat /></LocalRoute>} />
         <Route path="/models" element={<LocalRoute><Models /></LocalRoute>} />
         <Route path="/keys" element={<LocalRoute><Keys /></LocalRoute>} />
@@ -152,7 +145,6 @@ export default function App() {
         <Route path="/setup" element={<LocalRoute><Setup onComplete={() => window.location.href = '/home'} /></LocalRoute>} />
 
         {/* Cloud routes */}
-        <Route path="/onboarding" element={<RequireCloudAuth><Onboarding /></RequireCloudAuth>} />
         <Route path="/instances" element={<RequireCloudAuth><Instances /></RequireCloudAuth>} />
         <Route path="/instances/:id" element={<RequireCloudAuth><InstanceDetail /></RequireCloudAuth>}>
           <Route index element={<Home />} />

--- a/dashboard/src/components/Sidebar.tsx
+++ b/dashboard/src/components/Sidebar.tsx
@@ -6,115 +6,140 @@ import { useInstancesStore } from '../store/instances'
 import { useServerStore } from '../store/server'
 import ThemeToggle from './ThemeToggle'
 
-const localNavItems = [
-  {
-    to: '/home',
-    label: 'Home',
-    icon: (
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-        <rect x="3" y="3" width="7" height="7" /><rect x="14" y="3" width="7" height="7" /><rect x="14" y="14" width="7" height="7" /><rect x="3" y="14" width="7" height="7" />
-      </svg>
-    ),
-  },
-  {
-    to: '/models',
-    label: 'Models',
-    icon: (
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-        <polygon points="12 2 2 7 12 12 22 7 12 2" /><polyline points="2 17 12 22 22 17" /><polyline points="2 12 12 17 22 12" />
-      </svg>
-    ),
-  },
-  {
-    to: '/keys',
-    label: 'API Keys',
-    icon: (
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-        <path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4" />
-      </svg>
-    ),
-  },
-  {
-    to: '/activity',
-    label: 'Activity',
-    icon: (
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-        <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
-      </svg>
-    ),
-  },
-  {
-    to: '/settings',
-    label: 'Settings',
-    icon: (
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-        <circle cx="12" cy="12" r="3" /><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
-      </svg>
-    ),
-  },
-]
+interface NavSection {
+  label: string
+  items: { to: string; label: string; icon: React.ReactNode }[]
+}
 
-const accountNavItems = [
-  {
-    to: '/billing',
-    label: 'Billing',
-    icon: (
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-        <rect x="1" y="4" width="22" height="16" rx="2" ry="2" /><line x1="1" y1="10" x2="23" y2="10" />
-      </svg>
-    ),
-  },
-  {
-    to: '/team',
-    label: 'Team',
-    icon: (
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-        <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" /><circle cx="9" cy="7" r="4" /><path d="M23 21v-2a4 4 0 0 0-3-3.87" /><path d="M16 3.13a4 4 0 0 1 0 7.75" />
-      </svg>
-    ),
-  },
-  {
-    to: '/settings',
-    label: 'Settings',
-    icon: (
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-        <circle cx="12" cy="12" r="3" /><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
-      </svg>
-    ),
-  },
-]
+const buildSection: NavSection = {
+  label: 'Build',
+  items: [
+    {
+      to: '/home',
+      label: 'Dashboard',
+      icon: <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><rect x="3" y="3" width="7" height="7" /><rect x="14" y="3" width="7" height="7" /><rect x="14" y="14" width="7" height="7" /><rect x="3" y="14" width="7" height="7" /></svg>,
+    },
+    {
+      to: '/chat',
+      label: 'Chat',
+      icon: <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" /></svg>,
+    },
+    {
+      to: '/models',
+      label: 'Models',
+      icon: <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><polygon points="12 2 2 7 12 12 22 7 12 2" /><polyline points="2 17 12 22 22 17" /><polyline points="2 12 12 17 22 12" /></svg>,
+    },
+    {
+      to: '/providers',
+      label: 'Providers',
+      icon: <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z" /><polyline points="22 6 12 13 2 6" /></svg>,
+    },
+  ],
+}
 
-function NavItem({ to, label, icon, onClick }: { to: string; label: string; icon: React.ReactNode; onClick?: () => void }) {
+const agentsSection: NavSection = {
+  label: 'Agents',
+  items: [
+    {
+      to: '/sandboxes',
+      label: 'Sandboxes',
+      icon: <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><rect x="2" y="2" width="20" height="20" rx="2.18" ry="2.18" /><line x1="7" y1="2" x2="7" y2="22" /><line x1="17" y1="2" x2="17" y2="22" /><line x1="2" y1="12" x2="22" y2="12" /><line x1="2" y1="7" x2="7" y2="7" /><line x1="2" y1="17" x2="7" y2="17" /><line x1="17" y1="7" x2="22" y2="7" /><line x1="17" y1="17" x2="22" y2="17" /></svg>,
+    },
+  ],
+}
+
+const manageSection: NavSection = {
+  label: 'Manage',
+  items: [
+    {
+      to: '/keys',
+      label: 'API Keys',
+      icon: <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4" /></svg>,
+    },
+    {
+      to: '/activity',
+      label: 'Activity',
+      icon: <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12" /></svg>,
+    },
+    {
+      to: '/settings',
+      label: 'Settings',
+      icon: <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="3" /><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" /></svg>,
+    },
+  ],
+}
+
+const accountSection: NavSection = {
+  label: 'Account',
+  items: [
+    {
+      to: '/billing',
+      label: 'Billing',
+      icon: <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><rect x="1" y="4" width="22" height="16" rx="2" ry="2" /><line x1="1" y1="10" x2="23" y2="10" /></svg>,
+    },
+    {
+      to: '/team',
+      label: 'Team',
+      icon: <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" /><circle cx="9" cy="7" r="4" /><path d="M23 21v-2a4 4 0 0 0-3-3.87" /><path d="M16 3.13a4 4 0 0 1 0 7.75" /></svg>,
+    },
+    {
+      to: '/account',
+      label: 'Settings',
+      icon: <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="3" /><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" /></svg>,
+    },
+  ],
+}
+
+function NavItem({ to, label, icon, collapsed, onClick }: { to: string; label: string; icon: React.ReactNode; collapsed: boolean; onClick?: () => void }) {
   return (
     <NavLink
       to={to}
-      end
+      end={to === '/home'}
       onClick={onClick}
+      title={collapsed ? label : undefined}
       className={({ isActive }) =>
         `flex items-center gap-3 px-3 py-2 rounded-lg text-sm transition-colors ${
           isActive ? 'bg-white/15 text-white' : 'text-white/60 hover:text-white hover:bg-white/10'
-        }`
+        } ${collapsed ? 'justify-center' : ''}`
       }
     >
       {icon}
-      {label}
+      {!collapsed && label}
     </NavLink>
   )
 }
 
+function SectionGroup({ section, collapsed, onItemClick }: { section: NavSection; collapsed: boolean; onItemClick?: () => void }) {
+  return (
+    <div>
+      {!collapsed && (
+        <p className="px-3 pt-4 pb-1 text-[10px] font-medium text-white/40 uppercase tracking-wider">
+          {section.label}
+        </p>
+      )}
+      {collapsed && <div className="pt-3" />}
+      {section.items.map(item => (
+        <NavItem key={item.to} {...item} collapsed={collapsed} onClick={onItemClick} />
+      ))}
+    </div>
+  )
+}
+
 export default function Sidebar() {
-  const { sidebarOpen, setSidebarOpen } = useUIStore()
+  const { sidebarOpen, setSidebarOpen, sidebarCollapsed, toggleSidebarCollapsed } = useUIStore()
   const mode = useModeStore(s => s.mode)
   const user = useAuthStore(s => s.user)
   const instances = useInstancesStore(s => s.instances)
   const version = useServerStore(s => s.version)
   const tunnel = useServerStore(s => s.tunnel)
   const navigate = useNavigate()
-  const plan = user?.plan || 'free'
 
   const showLocal = mode === 'local' || mode === 'hybrid'
   const showCloud = mode === 'cloud' || mode === 'hybrid'
   const closeSidebar = () => setSidebarOpen(false)
+  const collapsed = sidebarCollapsed
+
+  const sidebarWidth = collapsed ? 'w-14' : 'w-60'
 
   return (
     <>
@@ -123,131 +148,129 @@ export default function Sidebar() {
         <div className="fixed inset-0 z-40 bg-black/50 lg:hidden" onClick={closeSidebar} />
       )}
 
-      <aside className={`fixed top-0 left-0 z-50 h-full w-60 bg-brand text-white flex flex-col transition-transform lg:translate-x-0 ${sidebarOpen ? 'translate-x-0' : '-translate-x-full'}`}>
-        {/* Logo */}
-        <div className="flex items-center gap-2.5 px-5 py-5">
-          <svg width="28" height="28" viewBox="0 0 28 28" fill="none" style={{filter: 'drop-shadow(0 0 6px rgba(108, 99, 255, 0.4))'}}>
-            <circle cx="14" cy="14" r="11" fill="white" />
-          </svg>
-          <div>
-            <div className="font-semibold text-sm">
-              {mode === 'cloud' ? 'Solon Cloud' : 'Solon'}
-            </div>
-            {showCloud && user ? (
-              <div className="text-[10px] text-white/50 uppercase tracking-wider">{plan}</div>
-            ) : (
-              <div className="text-[10px] text-white/50 uppercase tracking-wider">Dashboard</div>
-            )}
-          </div>
+      <aside className={`fixed top-0 left-0 z-50 h-full ${sidebarWidth} bg-brand text-white flex flex-col transition-all lg:translate-x-0 ${sidebarOpen ? 'translate-x-0' : '-translate-x-full'}`}>
+        {/* Logo + collapse toggle */}
+        <div className={`flex items-center ${collapsed ? 'justify-center px-2' : 'justify-between px-5'} py-4`}>
+          {collapsed ? (
+            <button onClick={toggleSidebarCollapsed} className="p-1 rounded-lg hover:bg-white/10 transition-colors">
+              <svg width="20" height="20" viewBox="0 0 28 28" fill="none" style={{filter: 'drop-shadow(0 0 6px rgba(108, 99, 255, 0.4))'}}>
+                <circle cx="14" cy="14" r="11" fill="white" />
+              </svg>
+            </button>
+          ) : (
+            <>
+              <div className="flex items-center gap-2.5">
+                <svg width="24" height="24" viewBox="0 0 28 28" fill="none" style={{filter: 'drop-shadow(0 0 6px rgba(108, 99, 255, 0.4))'}}>
+                  <circle cx="14" cy="14" r="11" fill="white" />
+                </svg>
+                <span className="font-semibold text-sm">
+                  {mode === 'cloud' ? 'Solon Cloud' : 'Solon'}
+                </span>
+              </div>
+              <button onClick={toggleSidebarCollapsed} className="p-1 rounded-lg text-white/40 hover:text-white/60 hover:bg-white/10 transition-colors">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <polyline points="11 17 6 12 11 7" /><polyline points="18 17 13 12 18 7" />
+                </svg>
+              </button>
+            </>
+          )}
         </div>
 
-        <div className="flex-1 overflow-y-auto px-3 space-y-1">
-          {/* Local instance section */}
+        <div className="flex-1 overflow-y-auto px-2 space-y-1">
+          {/* Local sections */}
           {showLocal && (
             <>
-              <p className="px-3 pt-2 pb-1 text-[10px] font-medium text-white/40 uppercase tracking-wider">
-                Local Instance
-              </p>
-              {localNavItems.map(item => (
-                <NavItem key={item.to} {...item} onClick={closeSidebar} />
-              ))}
+              <SectionGroup section={buildSection} collapsed={collapsed} onItemClick={closeSidebar} />
+              <SectionGroup section={agentsSection} collapsed={collapsed} onItemClick={closeSidebar} />
+              <SectionGroup section={manageSection} collapsed={collapsed} onItemClick={closeSidebar} />
             </>
           )}
 
-          {/* Remote instances section */}
+          {/* Cloud: instances */}
           {showCloud && user && (
             <>
-              <p className="px-3 pt-4 pb-1 text-[10px] font-medium text-white/40 uppercase tracking-wider flex items-center justify-between">
-                <span>{mode === 'cloud' ? 'Instances' : 'Remote Instances'}</span>
-                <button
-                  onClick={() => { closeSidebar(); navigate('/instances') }}
-                  className="text-[10px] text-white/40 hover:text-white/60 transition-colors"
-                >
-                  Manage
-                </button>
-              </p>
-              {instances.length === 0 ? (
-                <button
-                  onClick={() => { closeSidebar(); navigate('/instances') }}
-                  className="flex items-center gap-3 px-3 py-2 rounded-lg text-sm text-white/40 hover:text-white/60 hover:bg-white/5 transition-colors w-full"
-                >
-                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                    <circle cx="12" cy="12" r="10" /><line x1="12" y1="8" x2="12" y2="16" /><line x1="8" y1="12" x2="16" y2="12" />
-                  </svg>
-                  Add instance
-                </button>
-              ) : (
-                instances.map(inst => (
-                  <NavLink
-                    key={inst.id}
-                    to={`/instances/${inst.id}`}
-                    onClick={closeSidebar}
-                    className={({ isActive }) =>
-                      `flex items-center gap-3 px-3 py-2 rounded-lg text-sm transition-colors ${
-                        isActive ? 'bg-white/15 text-white' : 'text-white/60 hover:text-white hover:bg-white/10'
-                      }`
-                    }
-                  >
-                    <span className={`w-2 h-2 rounded-full ${
-                      inst.status === 'online' ? 'bg-green-400' : inst.status === 'offline' ? 'bg-red-400' : 'bg-gray-400'
-                    }`} />
-                    {inst.name}
-                  </NavLink>
-                ))
+              {!collapsed && (
+                <div>
+                  <p className="px-3 pt-4 pb-1 text-[10px] font-medium text-white/40 uppercase tracking-wider flex items-center justify-between">
+                    <span>Instances</span>
+                    <button
+                      onClick={() => { closeSidebar(); navigate('/instances') }}
+                      className="text-[10px] text-white/40 hover:text-white/60 transition-colors"
+                    >
+                      Manage
+                    </button>
+                  </p>
+                  {instances.length === 0 ? (
+                    <button
+                      onClick={() => { closeSidebar(); navigate('/instances') }}
+                      className="flex items-center gap-3 px-3 py-2 rounded-lg text-sm text-white/40 hover:text-white/60 hover:bg-white/5 transition-colors w-full"
+                    >
+                      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                        <circle cx="12" cy="12" r="10" /><line x1="12" y1="8" x2="12" y2="16" /><line x1="8" y1="12" x2="16" y2="12" />
+                      </svg>
+                      Add instance
+                    </button>
+                  ) : (
+                    instances.map(inst => (
+                      <NavLink
+                        key={inst.id}
+                        to={`/instances/${inst.id}`}
+                        onClick={closeSidebar}
+                        className={({ isActive }) =>
+                          `flex items-center gap-3 px-3 py-2 rounded-lg text-sm transition-colors ${
+                            isActive ? 'bg-white/15 text-white' : 'text-white/60 hover:text-white hover:bg-white/10'
+                          }`
+                        }
+                      >
+                        <span className={`w-2 h-2 rounded-full ${
+                          inst.status === 'online' ? 'bg-green-400' : inst.status === 'offline' ? 'bg-red-400' : 'bg-gray-400'
+                        }`} />
+                        {inst.name}
+                      </NavLink>
+                    ))
+                  )}
+                </div>
               )}
 
-              {/* Admin section */}
-              {user.role === 'admin' && (
-                <>
-                  <p className="px-3 pt-4 pb-1 text-[10px] font-medium text-white/40 uppercase tracking-wider">
-                    Admin
-                  </p>
+              {/* Admin */}
+              {user.role === 'admin' && !collapsed && (
+                <div>
+                  <p className="px-3 pt-4 pb-1 text-[10px] font-medium text-white/40 uppercase tracking-wider">Admin</p>
                   <NavItem
                     to="/admin/users"
                     label="Users"
-                    icon={
-                      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                        <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" /><circle cx="9" cy="7" r="4" /><path d="M23 21v-2a4 4 0 0 0-3-3.87" /><path d="M16 3.13a4 4 0 0 1 0 7.75" />
-                      </svg>
-                    }
+                    collapsed={collapsed}
+                    icon={<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" /><circle cx="9" cy="7" r="4" /><path d="M23 21v-2a4 4 0 0 0-3-3.87" /><path d="M16 3.13a4 4 0 0 1 0 7.75" /></svg>}
                     onClick={closeSidebar}
                   />
-                </>
+                </div>
               )}
 
-              {/* Account section */}
-              <p className="px-3 pt-4 pb-1 text-[10px] font-medium text-white/40 uppercase tracking-wider">
-                Account
-              </p>
-              {accountNavItems.map(item => (
-                <NavItem key={item.to} {...item} onClick={closeSidebar} />
-              ))}
+              <SectionGroup section={accountSection} collapsed={collapsed} onItemClick={closeSidebar} />
             </>
           )}
         </div>
 
         {/* Bottom bar */}
-        <div className="px-3 py-4 border-t border-white/10 flex items-center justify-between">
+        <div className={`px-2 py-3 border-t border-white/10 ${collapsed ? 'flex flex-col items-center gap-2' : 'flex items-center justify-between'}`}>
           <ThemeToggle />
-          {showLocal && !user && mode === 'local' && (
+          {!collapsed && showLocal && !user && mode === 'local' && (
             <button
               onClick={() => { closeSidebar(); navigate('/login') }}
               className="text-xs text-white/40 hover:text-white/60 transition-colors"
             >
-              Sign in to Cloud &rarr;
+              Sign in &rarr;
             </button>
           )}
-          {showLocal && (
+          {!collapsed && showLocal && (
             <span className="text-[11px] text-white/25 flex items-center gap-1.5">
               {tunnel?.enabled && <span className="w-2 h-2 rounded-full bg-green-400" />}
               {version ? `v${version}` : ''}
             </span>
           )}
-          {user && (
-            <div className="flex items-center gap-2">
-              <div className="h-6 w-6 rounded-full bg-brand-light flex items-center justify-center text-white text-[10px] font-medium">
-                {user.name?.charAt(0).toUpperCase() || '?'}
-              </div>
+          {!collapsed && user && (
+            <div className="h-6 w-6 rounded-full bg-brand-light flex items-center justify-center text-white text-[10px] font-medium">
+              {user.name?.charAt(0).toUpperCase() || '?'}
             </div>
           )}
         </div>

--- a/dashboard/src/layouts/AppLayout.tsx
+++ b/dashboard/src/layouts/AppLayout.tsx
@@ -4,11 +4,13 @@ import Sidebar from '../components/Sidebar'
 import { useInstancesStore } from '../store/instances'
 import { useModeStore } from '../store/mode'
 import { useServerStore } from '../store/server'
+import { useUIStore } from '../store/ui'
 
 export default function AppLayout() {
   const load = useInstancesStore(s => s.load)
   const mode = useModeStore(s => s.mode)
   const fetchServer = useServerStore(s => s.fetch)
+  const collapsed = useUIStore(s => s.sidebarCollapsed)
 
   useEffect(() => {
     if (mode !== 'local') {
@@ -25,7 +27,7 @@ export default function AppLayout() {
   return (
     <div className="min-h-screen bg-[var(--bg)]">
       <Sidebar />
-      <div className="lg:pl-60">
+      <div className={`transition-all ${collapsed ? 'lg:pl-14' : 'lg:pl-60'}`}>
         <Outlet />
       </div>
     </div>

--- a/dashboard/src/pages/Home.tsx
+++ b/dashboard/src/pages/Home.tsx
@@ -1,11 +1,26 @@
 import { useState, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { useInstanceContext } from '../contexts/InstanceContext'
 import { useServerStore } from '../store/server'
+import { useAuthStore } from '../store/auth'
+import { useModeStore } from '../store/mode'
 import Card from '../components/Card'
-import Setup from './instance/Setup'
-import { providerAPI, sandboxAPI } from '../api/local'
+import { providerAPI } from '../api/local'
 import { fetchJSON } from '../api/client'
 import type { UsageStats, ModelInfo } from '../api/types'
+
+function getGreeting(): string {
+  const h = new Date().getHours()
+  if (h < 12) return 'Good morning'
+  if (h < 18) return 'Good afternoon'
+  return 'Good evening'
+}
+
+function formatNumber(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`
+  return String(n)
+}
 
 function StatCard({ label, value, sub }: { label: string; value: string; sub?: string }) {
   return (
@@ -17,138 +32,29 @@ function StatCard({ label, value, sub }: { label: string; value: string; sub?: s
   )
 }
 
-function formatNumber(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`
-  return String(n)
-}
-
-export default function Home() {
-  const { api } = useInstanceContext()
-  const status = useServerStore(s => s.status)
-  const version = useServerStore(s => s.version)
-  const [stats, setStats] = useState<UsageStats | null>(null)
-  const [models, setModels] = useState<ModelInfo[]>([])
-  const [loading, setLoading] = useState(true)
-  const [showSetup, setShowSetup] = useState(false)
-  const [hasProviders, setHasProviders] = useState<boolean | null>(null)
-
-  useEffect(() => {
-    Promise.all([
-      api.analytics.usage().then(setStats).catch(() => {}),
-      api.models().then(setModels).catch(() => {}),
-      providerAPI.list().then(p => setHasProviders(p.length > 0)).catch(() => setHasProviders(false)),
-    ]).finally(() => setLoading(false))
-  }, [api])
-
-  const isOnline = status === 'online'
-  const hasActivity = stats && stats.total_requests > 0
-  const hasModels = models.length > 0
-
-  // Show guided setup wizard when no providers and no models (fresh install)
-  if (!loading && hasProviders === false && !hasModels && !hasActivity) {
-    return <Setup onComplete={() => { setShowSetup(false); setHasProviders(true) }} />
-  }
-
-  if (loading) {
-    return (
-      <main className="max-w-4xl mx-auto px-4 sm:px-6 py-8">
-        <p className="text-sm text-[var(--text-tertiary)]">Loading...</p>
-      </main>
-    )
-  }
-
-  // First-run: no models, no requests → show get started card
-  if (!hasModels && !hasActivity) {
-    return (
-      <main className="max-w-3xl mx-auto px-4 sm:px-6 py-8 space-y-6">
-        <div className="flex items-center gap-3">
-          <span className={`w-2.5 h-2.5 rounded-full ${isOnline ? 'bg-green-500 animate-pulse-dot' : 'bg-red-500'}`} />
-          <h1 className="text-2xl font-bold tracking-tight text-[var(--text)]">
-            {isOnline ? 'Solon is running' : 'Solon'}
-          </h1>
-          {version && <span className="text-xs font-mono text-[var(--text-tertiary)]">v{version}</span>}
-        </div>
-
-        <Card className="p-6 space-y-4">
-          <h2 className="text-lg font-semibold text-[var(--text)]">Get Started</h2>
-          <p className="text-sm text-[var(--text-secondary)]">
-            Pull your first model to start using Solon. Try one of these:
-          </p>
-          <div className="space-y-2 font-mono text-sm">
-            <p className="bg-[var(--bg-input)] border border-[var(--border-input)] rounded-lg px-3 py-2 text-[var(--text)]">
-              solon models pull llama3.2:3b
-            </p>
-            <p className="bg-[var(--bg-input)] border border-[var(--border-input)] rounded-lg px-3 py-2 text-[var(--text)]">
-              solon models pull mistral:7b
-            </p>
-          </div>
-          <p className="text-xs text-[var(--text-tertiary)]">
-            Or go to the Models page to browse and install from the library.
-          </p>
-        </Card>
-      </main>
-    )
-  }
-
+function ActionButton({ label, description, onClick, muted }: { label: string; description: string; onClick: () => void; muted?: boolean }) {
   return (
-    <main className="max-w-4xl mx-auto px-4 sm:px-6 py-8 space-y-8">
-      <div className="flex items-center gap-3">
-        <span className={`w-2.5 h-2.5 rounded-full ${isOnline ? 'bg-green-500 animate-pulse-dot' : 'bg-red-500'}`} />
-        <h1 className="text-2xl font-bold tracking-tight text-[var(--text)]">Dashboard</h1>
-        {version && <span className="text-xs font-mono text-[var(--text-tertiary)]">v{version}</span>}
-      </div>
-
-      {/* OpenClaw launch card */}
-      {hasProviders && <OpenClawCard />}
-
-      {/* Stats grid */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
-        <StatCard
-          label="Requests Today"
-          value={stats ? formatNumber(stats.requests_today) : '0'}
-        />
-        <StatCard
-          label="Total Tokens"
-          value={stats ? formatNumber(stats.total_tokens_in + stats.total_tokens_out) : '0'}
-          sub={stats ? `${formatNumber(stats.total_tokens_in)} in / ${formatNumber(stats.total_tokens_out)} out` : undefined}
-        />
-        <StatCard
-          label="Avg Latency"
-          value={stats && stats.avg_latency_ms > 0 ? `${Math.round(stats.avg_latency_ms)}ms` : '—'}
-        />
-        <StatCard
-          label="Most Used"
-          value={stats?.most_used_model || '—'}
-        />
-      </div>
-
-      {/* Summary row */}
-      <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
-        <StatCard
-          label="Total Requests"
-          value={stats ? formatNumber(stats.total_requests) : '0'}
-        />
-        <StatCard
-          label="API Keys Active"
-          value={stats ? String(stats.unique_keys_used) : '0'}
-        />
-        <StatCard
-          label="Models Installed"
-          value={String(models.length)}
-        />
-      </div>
-    </main>
+    <button
+      onClick={onClick}
+      className={`flex-1 text-left px-5 py-4 rounded-xl border transition-colors ${
+        muted
+          ? 'border-[var(--border)] bg-[var(--bg-card)] text-[var(--text-tertiary)] cursor-default'
+          : 'border-[var(--border)] bg-[var(--bg-card)] hover:border-brand-light/30 hover:bg-[var(--card-hover)] text-[var(--text)]'
+      }`}
+    >
+      <span className="text-sm font-semibold">{label}</span>
+      <p className="mt-0.5 text-xs text-[var(--text-tertiary)]">{description}</p>
+    </button>
   )
 }
 
 function OpenClawCard() {
   const [launching, setLaunching] = useState(false)
-  const [status, setStatus] = useState<{ running: boolean; sandbox?: { status: string } } | null>(null)
+  const [status, setStatus] = useState<{ running: boolean } | null>(null)
   const [error, setError] = useState('')
 
   useEffect(() => {
-    fetchJSON<{ available: boolean; running: boolean; sandbox?: { status: string } }>('/api/v1/openclaw/status')
+    fetchJSON<{ available: boolean; running: boolean }>('/api/v1/openclaw/status')
       .then(setStatus)
       .catch(() => {})
   }, [])
@@ -158,8 +64,7 @@ function OpenClawCard() {
     setError('')
     try {
       await fetchJSON('/api/v1/openclaw/start', { method: 'POST' })
-      // Refresh status
-      const s = await fetchJSON<{ available: boolean; running: boolean; sandbox?: { status: string } }>('/api/v1/openclaw/status')
+      const s = await fetchJSON<{ available: boolean; running: boolean }>('/api/v1/openclaw/status')
       setStatus(s)
     } catch (e) {
       setError((e as Error).message)
@@ -173,16 +78,13 @@ function OpenClawCard() {
   return (
     <Card className="p-5">
       <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <span className="text-2xl">&#x1F99E;</span>
-          <div>
-            <h3 className="text-sm font-semibold text-[var(--text)]">OpenClaw</h3>
-            <p className="text-xs text-[var(--text-tertiary)]">
-              {isRunning ? 'Running in secure sandbox' : 'AI agent framework — run safely in a sandbox'}
-            </p>
-          </div>
+        <div>
+          <h3 className="text-sm font-semibold text-[var(--text)]">OpenClaw Agent</h3>
+          <p className="text-xs text-[var(--text-tertiary)]">
+            {isRunning ? 'Running in secure sandbox' : 'AI agent with tools and web access'}
+          </p>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-3">
           {isRunning && (
             <span className="flex items-center gap-1.5 text-xs text-green-400">
               <span className="w-2 h-2 rounded-full bg-green-400 animate-pulse" />
@@ -194,22 +96,132 @@ function OpenClawCard() {
             disabled={launching}
             className={`px-4 py-2 rounded-lg text-sm font-medium transition-opacity disabled:opacity-50 ${
               isRunning
-                ? 'bg-[var(--bg-hover)] text-[var(--text-secondary)] hover:bg-[var(--border)]'
-                : 'bg-[var(--accent)] text-white hover:opacity-90'
+                ? 'bg-[var(--bg-hover)] text-[var(--text-secondary)]'
+                : 'bg-brand text-white hover:opacity-90'
             }`}
           >
-            {launching ? 'Starting...' : isRunning ? 'Restart' : 'Launch OpenClaw'}
+            {launching ? 'Starting...' : isRunning ? 'Restart' : 'Launch'}
           </button>
         </div>
       </div>
-      {isRunning && (
-        <p className="mt-3 text-xs text-[var(--text-tertiary)] font-mono bg-[var(--bg)] rounded-lg px-3 py-2">
-          solon openclaw
-        </p>
-      )}
-      {error && (
-        <p className="mt-2 text-xs text-red-400">{error}</p>
-      )}
+      {error && <p className="mt-2 text-xs text-red-400">{error}</p>}
     </Card>
+  )
+}
+
+export default function Home() {
+  const navigate = useNavigate()
+  const mode = useModeStore(s => s.mode)
+  const user = useAuthStore(s => s.user)
+  const status = useServerStore(s => s.status)
+  const version = useServerStore(s => s.version)
+
+  const [stats, setStats] = useState<UsageStats | null>(null)
+  const [models, setModels] = useState<ModelInfo[]>([])
+  const [hasProviders, setHasProviders] = useState<boolean | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  const isLocal = mode === 'local' || mode === 'hybrid'
+  const isOnline = status === 'online'
+  const name = user?.name?.split(' ')[0] || (isLocal ? '' : null)
+
+  useEffect(() => {
+    if (!isLocal) {
+      setLoading(false)
+      return
+    }
+    // Only try to fetch when we have a local instance context
+    Promise.all([
+      fetch('/api/v1/analytics/usage').then(r => r.ok ? r.json() : null).then(setStats).catch(() => {}),
+      fetch('/api/v1/models').then(r => r.ok ? r.json() : null).then(d => setModels(d?.models || [])).catch(() => {}),
+      providerAPI.list().then(p => setHasProviders(p.length > 0)).catch(() => setHasProviders(false)),
+    ]).finally(() => setLoading(false))
+  }, [isLocal])
+
+  const hasActivity = stats && stats.total_requests > 0
+
+  return (
+    <main className="max-w-4xl mx-auto px-4 sm:px-6 py-8 space-y-8">
+      {/* Greeting */}
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight text-[var(--text)]">
+          {getGreeting()}{name ? `, ${name}` : ''}.
+        </h1>
+        {isLocal && (
+          <div className="mt-1 flex items-center gap-2">
+            <span className={`w-2 h-2 rounded-full ${isOnline ? 'bg-green-500' : 'bg-red-500'}`} />
+            <span className="text-sm text-[var(--text-tertiary)]">
+              {isOnline ? 'Solon is running' : 'Solon is offline'}
+              {version ? ` \u00b7 v${version}` : ''}
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* Three action buttons */}
+      <div className="flex gap-3">
+        <ActionButton
+          label="+ Create Agent"
+          description="OpenClaw in a secure sandbox"
+          onClick={() => navigate('/sandboxes')}
+        />
+        <ActionButton
+          label="Run Model Locally"
+          description="Pull and run open-source models"
+          onClick={() => navigate('/models')}
+        />
+        <ActionButton
+          label="Run Model in Cloud"
+          description="Managed GPU hosting"
+          onClick={() => {}}
+          muted
+        />
+      </div>
+
+      {/* OpenClaw card — if providers configured */}
+      {isLocal && hasProviders && <OpenClawCard />}
+
+      {/* Stats — if has activity */}
+      {isLocal && hasActivity && stats && (
+        <>
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+            <StatCard label="Requests Today" value={formatNumber(stats.requests_today)} />
+            <StatCard
+              label="Total Tokens"
+              value={formatNumber(stats.total_tokens_in + stats.total_tokens_out)}
+              sub={`${formatNumber(stats.total_tokens_in)} in / ${formatNumber(stats.total_tokens_out)} out`}
+            />
+            <StatCard
+              label="Avg Latency"
+              value={stats.avg_latency_ms > 0 ? `${Math.round(stats.avg_latency_ms)}ms` : '--'}
+            />
+            <StatCard label="Most Used" value={stats.most_used_model || '--'} />
+          </div>
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
+            <StatCard label="Total Requests" value={formatNumber(stats.total_requests)} />
+            <StatCard label="API Keys Active" value={String(stats.unique_keys_used)} />
+            <StatCard label="Models Installed" value={String(models.length)} />
+          </div>
+        </>
+      )}
+
+      {/* Empty state for new users */}
+      {isLocal && !loading && !hasActivity && !hasProviders && (
+        <Card className="p-6 text-center">
+          <p className="text-sm text-[var(--text-secondary)]">
+            Pick one of the options above to get started. Add a provider key, pull a model, or create an agent.
+          </p>
+        </Card>
+      )}
+
+      {/* Cloud empty state */}
+      {!isLocal && (
+        <Card className="p-6 text-center">
+          <p className="text-sm text-[var(--text-secondary)]">
+            Connect a Solon instance or deploy a managed server to get started.
+          </p>
+        </Card>
+      )}
+    </main>
   )
 }

--- a/dashboard/src/store/ui.ts
+++ b/dashboard/src/store/ui.ts
@@ -11,10 +11,12 @@ interface Toast {
 interface UIState {
   theme: Theme
   sidebarOpen: boolean
+  sidebarCollapsed: boolean
   toasts: Toast[]
   setTheme: (theme: Theme) => void
   toggleTheme: () => void
   setSidebarOpen: (open: boolean) => void
+  toggleSidebarCollapsed: () => void
   addToast: (message: string, type?: Toast['type']) => void
   removeToast: (id: string) => void
 }
@@ -22,6 +24,7 @@ interface UIState {
 export const useUIStore = create<UIState>((set, get) => ({
   theme: 'light',
   sidebarOpen: false,
+  sidebarCollapsed: localStorage.getItem('solon-sidebar-collapsed') === '1',
   toasts: [],
 
   setTheme: (theme) => {
@@ -37,6 +40,12 @@ export const useUIStore = create<UIState>((set, get) => ({
   },
 
   setSidebarOpen: (open) => set({ sidebarOpen: open }),
+
+  toggleSidebarCollapsed: () => {
+    const next = !get().sidebarCollapsed
+    localStorage.setItem('solon-sidebar-collapsed', next ? '1' : '0')
+    set({ sidebarCollapsed: next })
+  },
 
   addToast: (message, type = 'info') => {
     const id = Date.now().toString()


### PR DESCRIPTION
## Summary

- Home page redesigned: greeting + 3 action buttons (Create Agent / Run Model Locally / Run Model in Cloud) + stats grid for returning users
- Sidebar redesigned: collapsible, sectioned (BUILD / AGENTS / MANAGE), Chat + Providers + Sandboxes now in nav
- Onboarding page removed — home page handles both first-visit and returning user states
- Cloud mode root redirect goes to /home instead of /onboarding

## Test plan

- [ ] `cd dashboard && npm run build` passes
- [ ] Local mode: home shows greeting + 3 buttons + stats (if activity)
- [ ] Cloud mode: home shows greeting + 3 buttons + cloud empty state
- [ ] Sidebar sections are clear: BUILD, AGENTS, MANAGE
- [ ] Sidebar collapses/expands, state persists on reload
- [ ] All nav items (Chat, Models, Providers, Sandboxes, etc.) accessible
- [ ] No regressions in existing pages

Generated with [Claude Code](https://claude.com/claude-code)