### PR TITLE
feat: R2 model mirror — download from Solon CDN

### DIFF
--- a/internal/models/catalog.json
+++ b/internal/models/catalog.json
@@ -9,7 +9,7 @@
     "context": 128000,
     "vram": {"3b": 2.0, "8b": 4.7},
     "sources": {
-      "3b": {"repo": "bartowski/Llama-3.2-3B-Instruct-GGUF", "file": "Q4_K_M"},
+      "3b": {"repo": "bartowski/Llama-3.2-3B-Instruct-GGUF", "file": "Q4_K_M", "r2_url": "https://pub-ceabcf6fa0bd445f944e5343aab8cd05.r2.dev/llama3.2-3b-Q4_K_M.gguf"},
       "8b": {"repo": "bartowski/Meta-Llama-3.1-8B-Instruct-GGUF", "file": "Q4_K_M"}
     }
   },

--- a/internal/models/download.go
+++ b/internal/models/download.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -28,6 +29,106 @@ type DownloadResult struct {
 	RelPath  string // relative path under blobs dir, e.g. "blobs/sha256-abc123.gguf"
 	Size     int64
 	SHA256   string
+}
+
+// DownloadFromURL downloads a GGUF file from a direct URL (e.g. R2 mirror).
+func DownloadFromURL(ctx context.Context, url, blobsDir string, progressFn func(DownloadProgress)) (*DownloadResult, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("downloading from mirror: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("mirror returned %d", resp.StatusCode)
+	}
+
+	// Extract filename from URL
+	parts := strings.Split(url, "/")
+	filename := parts[len(parts)-1]
+	if filename == "" {
+		filename = "model.gguf"
+	}
+
+	tmpPath := filepath.Join(blobsDir, ".download-"+filename)
+	out, err := os.Create(tmpPath)
+	if err != nil {
+		return nil, fmt.Errorf("creating temp file: %w", err)
+	}
+	defer func() { _ = os.Remove(tmpPath) }()
+
+	total := resp.ContentLength
+
+	if progressFn != nil {
+		progressFn(DownloadProgress{Event: "start", File: filename, Total: total})
+	}
+
+	h := sha256.New()
+	var downloaded int64
+	buf := make([]byte, 256*1024) // 256KB chunks
+
+	for {
+		n, readErr := resp.Body.Read(buf)
+		if n > 0 {
+			if _, err := out.Write(buf[:n]); err != nil {
+				_ = out.Close()
+				return nil, fmt.Errorf("writing file: %w", err)
+			}
+			_, _ = h.Write(buf[:n])
+			downloaded += int64(n)
+
+			if progressFn != nil && total > 0 {
+				progressFn(DownloadProgress{
+					Event:      "progress",
+					File:       filename,
+					Downloaded: downloaded,
+					Total:      total,
+					Percent:    float64(downloaded) / float64(total) * 100,
+				})
+			}
+		}
+		if readErr == io.EOF {
+			break
+		}
+		if readErr != nil {
+			_ = out.Close()
+			return nil, fmt.Errorf("reading response: %w", readErr)
+		}
+	}
+	_ = out.Close()
+
+	hash := fmt.Sprintf("%x", h.Sum(nil))
+	blobName := fmt.Sprintf("sha256-%s.gguf", hash[:16])
+	blobPath := filepath.Join(blobsDir, blobName)
+	_ = os.Remove(blobPath)
+
+	if err := os.Rename(tmpPath, blobPath); err != nil {
+		if err := copyFile(tmpPath, blobPath); err != nil {
+			return nil, fmt.Errorf("moving file to blobs: %w", err)
+		}
+	}
+
+	if progressFn != nil {
+		progressFn(DownloadProgress{Event: "done", File: filename, Message: "download complete"})
+	}
+
+	info, _ := os.Stat(blobPath)
+	size := int64(0)
+	if info != nil {
+		size = info.Size()
+	}
+
+	return &DownloadResult{
+		Filename: filename,
+		RelPath:  filepath.Join("blobs", blobName),
+		Size:     size,
+		SHA256:   hash,
+	}, nil
 }
 
 // DownloadModel downloads a GGUF model from HuggingFace.

--- a/internal/models/registry.go
+++ b/internal/models/registry.go
@@ -12,8 +12,9 @@ import (
 
 // ModelSource maps a friendly name to a HuggingFace repo and file filter.
 type ModelSource struct {
-	Repo string `json:"repo"` // "bartowski/Llama-3.2-3B-Instruct-GGUF"
-	File string `json:"file"` // "Q4_K_M" (substring filter for GGUF filename)
+	Repo  string `json:"repo"`            // "bartowski/Llama-3.2-3B-Instruct-GGUF"
+	File  string `json:"file"`            // "Q4_K_M" (substring filter for GGUF filename)
+	R2URL string `json:"r2_url,omitempty"` // Direct download URL from Solon's R2 mirror
 }
 
 // DefaultModels contains built-in model name mappings, loaded from catalog.json.
@@ -74,15 +75,35 @@ func NewRegistry(dataDir string) (*Registry, error) {
 }
 
 // Pull downloads a model by name or direct HF repo reference.
+// Tries Solon's R2 mirror first, falls back to HuggingFace.
 func (r *Registry) Pull(ctx context.Context, name string, progressFn func(event DownloadProgress)) error {
 	source, err := r.resolveSource(name)
 	if err != nil {
 		return err
 	}
 
-	result, err := DownloadModel(ctx, source.Repo, source.File, filepath.Join(r.modelsDir, "blobs"), progressFn)
-	if err != nil {
-		return fmt.Errorf("downloading model %s: %w", name, err)
+	blobsDir := filepath.Join(r.modelsDir, "blobs")
+
+	// Try R2 mirror first
+	var result *DownloadResult
+	if source.R2URL != "" {
+		if progressFn != nil {
+			progressFn(DownloadProgress{Event: "start", Message: "downloading from Solon mirror"})
+		}
+		result, err = DownloadFromURL(ctx, source.R2URL, blobsDir, progressFn)
+		if err != nil {
+			// R2 failed — fall back to HuggingFace
+			result = nil
+			err = nil
+		}
+	}
+
+	// Fall back to HuggingFace
+	if result == nil {
+		result, err = DownloadModel(ctx, source.Repo, source.File, blobsDir, progressFn)
+		if err != nil {
+			return fmt.Errorf("downloading model %s: %w", name, err)
+		}
 	}
 
 	// Normalize model name for manifest filename

--- a/scripts/upload-model-r2.py
+++ b/scripts/upload-model-r2.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Download a GGUF model from HuggingFace and upload to Solon's R2 mirror."""
+
+import os
+import sys
+import subprocess
+import boto3
+
+R2_ENDPOINT = "https://e8ac4eb5225e608e3a5a10015cce94fa.eu.r2.cloudflarestorage.com"
+R2_BUCKET = "solon-models"
+
+MODELS = {
+    "llama3.2-3b-Q4_K_M.gguf": {
+        "repo": "bartowski/Llama-3.2-3B-Instruct-GGUF",
+        "pattern": "Q4_K_M",
+        "hf_file": "Llama-3.2-3B-Instruct-Q4_K_M.gguf",
+    },
+}
+
+def get_s3_client():
+    key_id = os.environ.get("R2_ACCESS_KEY_ID")
+    secret = os.environ.get("R2_SECRET_ACCESS_KEY")
+    if not key_id or not secret:
+        print("Error: Set R2_ACCESS_KEY_ID and R2_SECRET_ACCESS_KEY")
+        sys.exit(1)
+    return boto3.client("s3",
+        endpoint_url=R2_ENDPOINT,
+        aws_access_key_id=key_id,
+        aws_secret_access_key=secret,
+        region_name="auto",
+    )
+
+def upload_file(s3, local_path, r2_key):
+    size = os.path.getsize(local_path)
+    print(f"Uploading {r2_key} ({size / 1e9:.1f} GB)...")
+    s3.upload_file(local_path, R2_BUCKET, r2_key,
+        Callback=lambda bytes_transferred: None,
+        Config=boto3.s3.transfer.TransferConfig(
+            multipart_threshold=256 * 1024 * 1024,
+            multipart_chunksize=256 * 1024 * 1024,
+        ),
+    )
+    print(f"Done: https://pub-ceabcf6fa0bd445f944e5343aab8cd05.r2.dev/{r2_key}")
+
+def download_from_hf(repo, filename, output_dir):
+    """Download a specific file from HuggingFace using curl."""
+    url = f"https://huggingface.co/{repo}/resolve/main/{filename}"
+    output_path = os.path.join(output_dir, filename)
+    if os.path.exists(output_path):
+        print(f"Already downloaded: {output_path}")
+        return output_path
+    print(f"Downloading {url}...")
+    subprocess.run(["curl", "-L", "-o", output_path, "--progress-bar", url], check=True)
+    return output_path
+
+if __name__ == "__main__":
+    s3 = get_s3_client()
+    tmp_dir = "/tmp/solon-models"
+    os.makedirs(tmp_dir, exist_ok=True)
+
+    # If specific model name given, only do that one
+    target = sys.argv[1] if len(sys.argv) > 1 else None
+
+    for r2_key, info in MODELS.items():
+        if target and target != r2_key:
+            continue
+        local_path = download_from_hf(info["repo"], info["hf_file"], tmp_dir)
+        upload_file(s3, local_path, r2_key)


### PR DESCRIPTION
## Summary

- Models download from Solon's R2 mirror first, fall back to HuggingFace
- Solves gated model problem (Gemma, etc.) — we mirror them, customers download without tokens
- First model live: Llama 3.2 3B at `pub-ceabcf6fa0bd445f944e5343aab8cd05.r2.dev/llama3.2-3b-Q4_K_M.gguf`
- Upload script at `scripts/upload-model-r2.py` for adding more models

## Test plan

- [ ] `solon models pull llama3.2:3b` downloads from R2 (faster, no HF auth)
- [ ] If R2 is down, falls back to HuggingFace transparently
- [ ] Upload script works: downloads from HF, uploads to R2

## Next: mirror remaining 9 models (run upload script on Hetzner server for bandwidth)

Generated with [Claude Code](https://claude.com/claude-code)