### PR TITLE
fix: provisioner security hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,21 @@ jobs:
           command: deploy
           workingDirectory: cloud
 
+  provisioner:
+    needs: test
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy provisioner
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy
+          workingDirectory: provisioner
+
   install-worker:
     needs: test
     if: github.ref == 'refs/heads/master'

--- a/cloud/src/routes/webhooks.ts
+++ b/cloud/src/routes/webhooks.ts
@@ -171,6 +171,13 @@ webhooks.post('/provisioner', async (c) => {
   const sig = parts['v1']
   if (!timestamp || !sig) return c.json({ error: 'Invalid signature' }, 400)
 
+  // Reject signatures older than 5 minutes (prevent replay attacks)
+  const tsNum = parseInt(timestamp, 10)
+  const now = Math.floor(Date.now() / 1000)
+  if (Math.abs(now - tsNum) > 300) {
+    return c.json({ error: 'Signature timestamp expired' }, 401)
+  }
+
   const sigKey = await crypto.subtle.importKey(
     'raw',
     new TextEncoder().encode(c.env.PROVISIONER_SECRET),
@@ -195,7 +202,15 @@ webhooks.post('/provisioner', async (c) => {
     // Encrypt the Solon API key before storing
     let apiKeyEnc: string | null = null
     if (payload.solon_api_key) {
-      apiKeyEnc = await encrypt(payload.solon_api_key, c.env.ENCRYPTION_KEY)
+      try {
+        apiKeyEnc = await encrypt(payload.solon_api_key, c.env.ENCRYPTION_KEY)
+      } catch (err) {
+        console.error('Failed to encrypt API key:', err)
+        await c.env.DB.prepare(
+          `UPDATE managed_instances SET status = 'failed', updated_at = datetime('now') WHERE id = ?`,
+        ).bind(payload.instance_id).run()
+        return c.json({ error: 'Encryption failed' }, 500)
+      }
     }
 
     await c.env.DB.prepare(

--- a/provisioner/src/cloud-init.ts
+++ b/provisioner/src/cloud-init.ts
@@ -211,8 +211,9 @@ echo "[$(date)] Generating admin API key"
 API_KEY_OUTPUT=$(sudo -u solon /opt/solon/bin/solon keys create --name managed-admin --scope admin 2>&1)
 API_KEY=$(echo "$API_KEY_OUTPUT" | grep -oP 'sol_sk_live_[a-zA-Z0-9_]+' || true)
 if [ -z "$API_KEY" ]; then
-  echo "[$(date)] Warning: Could not extract API key from output: $API_KEY_OUTPUT"
-  API_KEY=""
+  echo "[$(date)] ERROR: Could not extract API key from output: $API_KEY_OUTPUT"
+  send_callback "failed" "" "" "Failed to extract API key from Solon keys command"
+  exit 1
 fi
 
 # Save key locally for debugging

--- a/provisioner/src/index.ts
+++ b/provisioner/src/index.ts
@@ -43,10 +43,19 @@ app.post('/webhook/provision', async (c) => {
 async function handleCreate(env: Env, request: ProvisionRequest): Promise<void> {
   const tier = request.tier ?? 'starter'
   const region = request.region ?? 'eu-central'
-  const name = request.name ?? `solon-${request.instance_id.slice(0, 8)}`
+  const rawName = request.name ?? `solon-${request.instance_id.slice(0, 8)}`
+  // Sanitize name: only allow lowercase alphanumeric and hyphens
+  const name = rawName.replace(/[^a-z0-9-]/gi, '').slice(0, 63).toLowerCase()
 
-  const serverType = TIER_SERVER_TYPES[tier] ?? 'cx22'
-  const location = REGION_LOCATIONS[region] ?? 'fsn1'
+  if (!TIER_SERVER_TYPES[tier]) {
+    throw new Error(`Invalid tier: ${tier}`)
+  }
+  if (!REGION_LOCATIONS[region]) {
+    throw new Error(`Invalid region: ${region}`)
+  }
+
+  const serverType = TIER_SERVER_TYPES[tier]
+  const location = REGION_LOCATIONS[region]
 
   const userData = generateCloudInit(env, {
     instanceId: request.instance_id,


### PR DESCRIPTION
## Summary

- Prevent replay attacks: validate HMAC timestamp (5-min tolerance) in cloud API webhook
- Fail fast if API key extraction fails during provisioning (don't store empty keys)
- Handle encryption errors gracefully (mark instance as failed instead of hanging)
- Sanitize server name to prevent shell injection in cloud-init script
- Validate tier/region against allowed values
- Add provisioner to CI deploy pipeline

## Provisioner Status

Deployed and live at `solon-provisioner.madaxamas.workers.dev` with all secrets configured.

## Test plan

- [ ] Provisioner health check: `curl https://solon-provisioner.madaxamas.workers.dev/health`
- [ ] Replay attack blocked: old signatures rejected with 401
- [ ] Invalid tier/region returns error instead of defaulting silently

Generated with [Claude Code](https://claude.com/claude-code)