### PR TITLE
feat: finish agent track — settings, channels, chat sidebar, header controls

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -23,6 +23,7 @@ import Activity from './pages/instance/Activity'
 import InstanceSettings from './pages/instance/InstanceSettings'
 import Setup from './pages/instance/Setup'
 import OpenClawUI from './pages/instance/OpenClawUI'
+import AgentSettings from './pages/instance/AgentSettings'
 
 // Cloud pages
 import Login from './pages/cloud/Login'
@@ -163,6 +164,7 @@ export default function App() {
         <Route path="/settings" element={<LocalRoute><InstanceSettings /></LocalRoute>} />
         <Route path="/setup" element={<LocalRoute><Setup onComplete={() => window.location.href = '/home'} /></LocalRoute>} />
         <Route path="/openclaw" element={<LocalRoute><OpenClawUI /></LocalRoute>} />
+        <Route path="/agent-settings" element={<LocalRoute><AgentSettings /></LocalRoute>} />
 
         {/* Cloud routes */}
         <Route path="/instances" element={<RequireCloudAuth><Instances /></RequireCloudAuth>} />

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -1,5 +1,4 @@
-import { useEffect, useState, useCallback, Component } from 'react'
-import type { ErrorInfo, ReactNode } from 'react'
+import { useEffect, useState, useCallback } from 'react'
 import { Routes, Route, Navigate } from 'react-router-dom'
 import { useAuth } from './hooks/useAuth'
 import { useTheme } from './hooks/useTheme'
@@ -36,26 +35,6 @@ import Team from './pages/cloud/Team'
 import AccountSettings from './pages/cloud/AccountSettings'
 import Users from './pages/cloud/Users'
 // Onboarding merged into Home page
-
-class ErrorBoundary extends Component<{ children: ReactNode }, { error: Error | null }> {
-  state = { error: null as Error | null }
-  static getDerivedStateFromError(error: Error) { return { error } }
-  componentDidCatch(error: Error, info: ErrorInfo) { console.error('React crash:', error, info) }
-  render() {
-    if (this.state.error) {
-      return (
-        <div style={{ padding: 40, fontFamily: 'monospace', color: '#c00' }}>
-          <h2>Page crashed</h2>
-          <pre style={{ whiteSpace: 'pre-wrap' }}>{this.state.error.message}</pre>
-          <pre style={{ whiteSpace: 'pre-wrap', fontSize: 12, color: '#666' }}>{this.state.error.stack}</pre>
-          <button onClick={() => { this.setState({ error: null }); window.location.reload() }}
-            style={{ marginTop: 16, padding: '8px 16px', cursor: 'pointer' }}>Reload</button>
-        </div>
-      )
-    }
-    return this.props.children
-  }
-}
 
 function RequireLocal({ children }: { children: React.ReactNode }) {
   const mode = useModeStore(s => s.mode)
@@ -157,7 +136,7 @@ export default function App() {
   }
 
   return (
-    <ErrorBoundary>
+    <>
     <ToastContainer />
     <Routes>
       {/* OAuth callback (no layout) */}
@@ -207,6 +186,6 @@ export default function App() {
       {/* Catch-all */}
       <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>
-    </ErrorBoundary>
+    </>
   )
 }

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState, useCallback } from 'react'
+import { useEffect, useState, useCallback, Component } from 'react'
+import type { ErrorInfo, ReactNode } from 'react'
 import { Routes, Route, Navigate } from 'react-router-dom'
 import { useAuth } from './hooks/useAuth'
 import { useTheme } from './hooks/useTheme'
@@ -35,6 +36,26 @@ import Team from './pages/cloud/Team'
 import AccountSettings from './pages/cloud/AccountSettings'
 import Users from './pages/cloud/Users'
 // Onboarding merged into Home page
+
+class ErrorBoundary extends Component<{ children: ReactNode }, { error: Error | null }> {
+  state = { error: null as Error | null }
+  static getDerivedStateFromError(error: Error) { return { error } }
+  componentDidCatch(error: Error, info: ErrorInfo) { console.error('React crash:', error, info) }
+  render() {
+    if (this.state.error) {
+      return (
+        <div style={{ padding: 40, fontFamily: 'monospace', color: '#c00' }}>
+          <h2>Page crashed</h2>
+          <pre style={{ whiteSpace: 'pre-wrap' }}>{this.state.error.message}</pre>
+          <pre style={{ whiteSpace: 'pre-wrap', fontSize: 12, color: '#666' }}>{this.state.error.stack}</pre>
+          <button onClick={() => { this.setState({ error: null }); window.location.reload() }}
+            style={{ marginTop: 16, padding: '8px 16px', cursor: 'pointer' }}>Reload</button>
+        </div>
+      )
+    }
+    return this.props.children
+  }
+}
 
 function RequireLocal({ children }: { children: React.ReactNode }) {
   const mode = useModeStore(s => s.mode)
@@ -136,7 +157,7 @@ export default function App() {
   }
 
   return (
-    <>
+    <ErrorBoundary>
     <ToastContainer />
     <Routes>
       {/* OAuth callback (no layout) */}
@@ -186,6 +207,6 @@ export default function App() {
       {/* Catch-all */}
       <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>
-    </>
+    </ErrorBoundary>
   )
 }

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -22,6 +22,7 @@ import Sandboxes from './pages/instance/Sandboxes'
 import Activity from './pages/instance/Activity'
 import InstanceSettings from './pages/instance/InstanceSettings'
 import Setup from './pages/instance/Setup'
+import OpenClawUI from './pages/instance/OpenClawUI'
 
 // Cloud pages
 import Login from './pages/cloud/Login'
@@ -161,6 +162,7 @@ export default function App() {
         <Route path="/activity" element={<LocalRoute><Activity /></LocalRoute>} />
         <Route path="/settings" element={<LocalRoute><InstanceSettings /></LocalRoute>} />
         <Route path="/setup" element={<LocalRoute><Setup onComplete={() => window.location.href = '/home'} /></LocalRoute>} />
+        <Route path="/openclaw" element={<LocalRoute><OpenClawUI /></LocalRoute>} />
 
         {/* Cloud routes */}
         <Route path="/instances" element={<RequireCloudAuth><Instances /></RequireCloudAuth>} />

--- a/dashboard/src/components/Sidebar.tsx
+++ b/dashboard/src/components/Sidebar.tsx
@@ -50,6 +50,11 @@ const agentsSection: NavSection = {
       label: 'OpenClaw UI',
       icon: <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><path d="M12 2L2 7l10 5 10-5-10-5z" /><path d="M2 17l10 5 10-5" /><path d="M2 12l10 5 10-5" /></svg>,
     },
+    {
+      to: '/agent-settings',
+      label: 'Agent Settings',
+      icon: <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="3" /><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" /></svg>,
+    },
   ],
 }
 

--- a/dashboard/src/components/Sidebar.tsx
+++ b/dashboard/src/components/Sidebar.tsx
@@ -45,6 +45,11 @@ const agentsSection: NavSection = {
       label: 'Sandboxes',
       icon: <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><rect x="2" y="2" width="20" height="20" rx="2.18" ry="2.18" /><line x1="7" y1="2" x2="7" y2="22" /><line x1="17" y1="2" x2="17" y2="22" /><line x1="2" y1="12" x2="22" y2="12" /><line x1="2" y1="7" x2="7" y2="7" /><line x1="2" y1="17" x2="7" y2="17" /><line x1="17" y1="7" x2="22" y2="7" /><line x1="17" y1="17" x2="22" y2="17" /></svg>,
     },
+    {
+      to: '/openclaw',
+      label: 'OpenClaw UI',
+      icon: <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><path d="M12 2L2 7l10 5 10-5-10-5z" /><path d="M2 17l10 5 10-5" /><path d="M2 12l10 5 10-5" /></svg>,
+    },
   ],
 }
 

--- a/dashboard/src/components/TerminalAccess.tsx
+++ b/dashboard/src/components/TerminalAccess.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react'
+
+interface Props {
+  isOpen: boolean
+  onClose: () => void
+  serverHost?: string
+}
+
+function CopyBlock({ label, command }: { label: string; command: string }) {
+  const [copied, setCopied] = useState(false)
+
+  function handleCopy() {
+    navigator.clipboard.writeText(command).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    })
+  }
+
+  return (
+    <div>
+      <p className="text-xs text-[var(--text-tertiary)] mb-1">{label}</p>
+      <div className="flex items-center gap-2">
+        <code className="flex-1 text-xs bg-[var(--bg)] px-3 py-2 rounded-lg font-mono text-[var(--text)] overflow-x-auto">
+          {command}
+        </code>
+        <button onClick={handleCopy}
+          className="px-2 py-2 text-xs rounded-lg border border-[var(--border)] hover:bg-[var(--bg-hover)] text-[var(--text-tertiary)] shrink-0">
+          {copied ? '✓' : '📋'}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default function TerminalAccess({ isOpen, onClose, serverHost }: Props) {
+  if (!isOpen) return null
+
+  const host = serverHost || window.location.hostname
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={onClose}>
+      <div className="bg-[var(--bg-card)] rounded-xl border border-[var(--border)] p-6 max-w-lg w-full mx-4 space-y-4"
+        onClick={e => e.stopPropagation()}>
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-[var(--text)]">Terminal Access</h2>
+          <button onClick={onClose} className="text-[var(--text-tertiary)] hover:text-[var(--text)]">✕</button>
+        </div>
+
+        <CopyBlock
+          label="1. SSH into your server"
+          command={`ssh root@${host}`}
+        />
+
+        <CopyBlock
+          label="2. Open the OpenClaw TUI"
+          command="docker exec -it openclaw-sandbox-openclaw openclaw tui"
+        />
+
+        <CopyBlock
+          label="3. Or send a one-off message"
+          command='docker exec openclaw-sandbox-openclaw openclaw agent --agent main --message "hello"'
+        />
+
+        <p className="text-xs text-[var(--text-tertiary)]">
+          The TUI gives you a full terminal interface to your agent with autocomplete, history, and streaming responses.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/dashboard/src/pages/Home.tsx
+++ b/dashboard/src/pages/Home.tsx
@@ -219,11 +219,11 @@ export default function Home() {
             <h3 className="text-sm font-semibold text-[var(--text)]">OpenClaw UI</h3>
             <p className="text-xs text-[var(--text-tertiary)] mt-1">Full control panel in a new tab</p>
           </button>
-          <button onClick={() => navigate('/settings')}
+          <button onClick={() => navigate('/agent-settings')}
             className="text-left p-5 rounded-xl border border-[var(--border)] bg-[var(--bg-card)] hover:border-blue-500/30 transition-colors">
-            <div className="text-2xl mb-2">📱</div>
-            <h3 className="text-sm font-semibold text-[var(--text)]">Channels</h3>
-            <p className="text-xs text-[var(--text-tertiary)] mt-1">Telegram, WhatsApp, Discord</p>
+            <div className="text-2xl mb-2">⚙️</div>
+            <h3 className="text-sm font-semibold text-[var(--text)]">Agent Settings</h3>
+            <p className="text-xs text-[var(--text-tertiary)] mt-1">Model, channels, workspace, skills</p>
           </button>
         </div>
       )}

--- a/dashboard/src/pages/Home.tsx
+++ b/dashboard/src/pages/Home.tsx
@@ -1,13 +1,16 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { useInstanceContext } from '../contexts/InstanceContext'
+import { useModeStore } from '../store/mode'
 import { useServerStore } from '../store/server'
 import { useAuthStore } from '../store/auth'
-import { useModeStore } from '../store/mode'
 import Card from '../components/Card'
-import { providerAPI } from '../api/local'
-import { fetchJSON } from '../api/client'
-import type { UsageStats, ModelInfo } from '../api/types'
+import { fetchJSON, getLocalApiKey, isNonLocalhost } from '../api/client'
+import type { UsageStats } from '../api/types'
+
+function authHeaders(): Record<string, string> {
+  const apiKey = isNonLocalhost() ? getLocalApiKey() : null
+  return apiKey ? { Authorization: `Bearer ${apiKey}` } : {}
+}
 
 function getGreeting(): string {
   const h = new Date().getHours()
@@ -22,91 +25,23 @@ function formatNumber(n: number): string {
   return String(n)
 }
 
-function StatCard({ label, value, sub }: { label: string; value: string; sub?: string }) {
-  return (
-    <Card className="p-5">
-      <p className="text-xs font-medium uppercase tracking-wider text-[var(--text-tertiary)]">{label}</p>
-      <p className="mt-1 text-2xl font-bold text-[var(--text)]">{value}</p>
-      {sub && <p className="mt-0.5 text-xs text-[var(--text-tertiary)]">{sub}</p>}
-    </Card>
-  )
-}
-
-function ActionButton({ label, description, onClick, muted }: { label: string; description: string; onClick: () => void; muted?: boolean }) {
-  return (
-    <button
-      onClick={onClick}
-      className={`flex-1 text-left px-5 py-4 rounded-xl border transition-colors ${
-        muted
-          ? 'border-[var(--border)] bg-[var(--bg-card)] text-[var(--text-tertiary)] cursor-default'
-          : 'border-[var(--border)] bg-[var(--bg-card)] hover:border-brand-light/30 hover:bg-[var(--card-hover)] text-[var(--text)]'
-      }`}
-    >
-      <span className="text-sm font-semibold">{label}</span>
-      <p className="mt-0.5 text-xs text-[var(--text-tertiary)]">{description}</p>
-    </button>
-  )
-}
-
-function OpenClawCard() {
-  const [launching, setLaunching] = useState(false)
-  const [status, setStatus] = useState<{ running: boolean } | null>(null)
-  const [error, setError] = useState('')
-
-  useEffect(() => {
-    fetchJSON<{ available: boolean; running: boolean }>('/api/v1/openclaw/status')
-      .then(setStatus)
-      .catch(() => {})
-  }, [])
-
-  const handleLaunch = async () => {
-    setLaunching(true)
-    setError('')
-    try {
-      await fetchJSON('/api/v1/openclaw/start', { method: 'POST' })
-      const s = await fetchJSON<{ available: boolean; running: boolean }>('/api/v1/openclaw/status')
-      setStatus(s)
-    } catch (e) {
-      setError((e as Error).message)
-    } finally {
-      setLaunching(false)
-    }
+interface AgentStatus {
+  available: boolean
+  running: boolean
+  sandbox?: {
+    name: string
+    status: string
+    tier: number
   }
+}
 
-  const isRunning = status?.running
-
-  return (
-    <Card className="p-5">
-      <div className="flex items-center justify-between">
-        <div>
-          <h3 className="text-sm font-semibold text-[var(--text)]">OpenClaw Agent</h3>
-          <p className="text-xs text-[var(--text-tertiary)]">
-            {isRunning ? 'Running in secure sandbox' : 'AI agent with tools and web access'}
-          </p>
-        </div>
-        <div className="flex items-center gap-3">
-          {isRunning && (
-            <span className="flex items-center gap-1.5 text-xs text-green-400">
-              <span className="w-2 h-2 rounded-full bg-green-400 animate-pulse" />
-              Running
-            </span>
-          )}
-          <button
-            onClick={handleLaunch}
-            disabled={launching}
-            className={`px-4 py-2 rounded-lg text-sm font-medium transition-opacity disabled:opacity-50 ${
-              isRunning
-                ? 'bg-[var(--bg-hover)] text-[var(--text-secondary)]'
-                : 'bg-brand text-white hover:opacity-90'
-            }`}
-          >
-            {launching ? 'Starting...' : isRunning ? 'Restart' : 'Launch'}
-          </button>
-        </div>
-      </div>
-      {error && <p className="mt-2 text-xs text-red-400">{error}</p>}
-    </Card>
-  )
+interface SessionInfo {
+  key: string
+  sessionId: string
+  model: string
+  modelProvider: string
+  totalTokens: number
+  updatedAt: number
 }
 
 export default function Home() {
@@ -116,110 +51,293 @@ export default function Home() {
   const status = useServerStore(s => s.status)
   const version = useServerStore(s => s.version)
 
+  const [agentStatus, setAgentStatus] = useState<AgentStatus | null>(null)
   const [stats, setStats] = useState<UsageStats | null>(null)
-  const [models, setModels] = useState<ModelInfo[]>([])
-  const [hasProviders, setHasProviders] = useState<boolean | null>(null)
-  const [loading, setLoading] = useState(true)
+  const [sessions, setSessions] = useState<SessionInfo[]>([])
+  const [launching, setLaunching] = useState(false)
+  const [quickMsg, setQuickMsg] = useState('')
+  const [quickSending, setQuickSending] = useState(false)
+  const [quickReply, setQuickReply] = useState('')
+  const [error, setError] = useState('')
 
   const isLocal = mode === 'local' || mode === 'hybrid'
   const isOnline = status === 'online'
   const name = user?.name?.split(' ')[0] || (isLocal ? '' : null)
+  const isRunning = agentStatus?.running
+
+  const loadStatus = useCallback(async () => {
+    try {
+      const s = await fetchJSON<AgentStatus>('/api/v1/openclaw/status')
+      setAgentStatus(s)
+    } catch { /* */ }
+  }, [])
 
   useEffect(() => {
-    if (!isLocal) {
-      setLoading(false)
-      return
+    if (!isLocal) return
+    loadStatus()
+    fetchJSON<UsageStats>('/api/v1/analytics/usage').then(setStats).catch(() => {})
+    // Try to load sessions from OpenClaw
+    fetchJSON<{ sessions?: SessionInfo[] }>('/api/v1/openclaw/sessions')
+      .then(d => setSessions(d.sessions || []))
+      .catch(() => {})
+  }, [isLocal, loadStatus])
+
+  async function handleLaunch() {
+    setLaunching(true)
+    setError('')
+    try {
+      await fetchJSON('/api/v1/openclaw/start', { method: 'POST' })
+      await new Promise(r => setTimeout(r, 3000))
+      await loadStatus()
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setLaunching(false)
     }
-    // Only try to fetch when we have a local instance context
-    Promise.all([
-      fetch('/api/v1/analytics/usage').then(r => r.ok ? r.json() : null).then(setStats).catch(() => {}),
-      fetch('/api/v1/models').then(r => r.ok ? r.json() : null).then(d => setModels(d?.models || [])).catch(() => {}),
-      providerAPI.list().then(p => setHasProviders(p.length > 0)).catch(() => setHasProviders(false)),
-    ]).finally(() => setLoading(false))
-  }, [isLocal])
+  }
 
-  const hasActivity = stats && stats.total_requests > 0
+  async function handleQuickSend() {
+    const msg = quickMsg.trim()
+    if (!msg || quickSending) return
+    setQuickSending(true)
+    setQuickReply('')
+    try {
+      const resp = await fetch('/api/v1/openclaw/send', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeaders() },
+        body: JSON.stringify({ message: msg }),
+      })
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+      const data = await resp.json() as Record<string, unknown>
+      const result = data.result as Record<string, unknown> | undefined
+      const payloads = result?.payloads as { text?: string }[] | undefined
+      const reply = payloads?.[0]?.text || (data.reply as string) || JSON.stringify(data)
+      setQuickReply(reply)
+      setQuickMsg('')
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setQuickSending(false)
+    }
+  }
 
-  return (
-    <main className="max-w-4xl mx-auto px-4 sm:px-6 py-8 space-y-8">
-      {/* Greeting */}
-      <div>
-        <h1 className="text-2xl font-bold tracking-tight text-[var(--text)]">
-          {getGreeting()}{name ? `, ${name}` : ''}.
-        </h1>
-        {isLocal && (
-          <div className="mt-1 flex items-center gap-2">
-            <span className={`w-2 h-2 rounded-full ${isOnline ? 'bg-green-500' : 'bg-red-500'}`} />
-            <span className="text-sm text-[var(--text-tertiary)]">
-              {isOnline ? 'Solon is running' : 'Solon is offline'}
-              {version ? ` \u00b7 v${version}` : ''}
-            </span>
-          </div>
-        )}
-      </div>
+  function timeAgo(timestamp: number): string {
+    const diff = Date.now() - timestamp
+    const mins = Math.floor(diff / 60000)
+    if (mins < 60) return `${mins}m ago`
+    const hours = Math.floor(mins / 60)
+    if (hours < 24) return `${hours}h ago`
+    return `${Math.floor(hours / 24)}d ago`
+  }
 
-      {/* Three action buttons */}
-      <div className="flex gap-3">
-        <ActionButton
-          label="+ Create Agent"
-          description="OpenClaw in a secure sandbox"
-          onClick={() => navigate('/sandboxes')}
-        />
-        <ActionButton
-          label="Run Model Locally"
-          description="Pull and run open-source models"
-          onClick={() => navigate('/models')}
-        />
-        <ActionButton
-          label="Run Model in Cloud"
-          description="Managed GPU hosting"
-          onClick={() => {}}
-          muted
-        />
-      </div>
-
-      {/* OpenClaw card — if providers configured */}
-      {isLocal && hasProviders && <OpenClawCard />}
-
-      {/* Stats — if has activity */}
-      {isLocal && hasActivity && stats && (
-        <>
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
-            <StatCard label="Requests Today" value={formatNumber(stats.requests_today)} />
-            <StatCard
-              label="Total Tokens"
-              value={formatNumber(stats.total_tokens_in + stats.total_tokens_out)}
-              sub={`${formatNumber(stats.total_tokens_in)} in / ${formatNumber(stats.total_tokens_out)} out`}
-            />
-            <StatCard
-              label="Avg Latency"
-              value={stats.avg_latency_ms > 0 ? `${Math.round(stats.avg_latency_ms)}ms` : '--'}
-            />
-            <StatCard label="Most Used" value={stats.most_used_model || '--'} />
-          </div>
-          <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
-            <StatCard label="Total Requests" value={formatNumber(stats.total_requests)} />
-            <StatCard label="API Keys Active" value={String(stats.unique_keys_used)} />
-            <StatCard label="Models Installed" value={String(models.length)} />
-          </div>
-        </>
-      )}
-
-      {/* Empty state for new users */}
-      {isLocal && !loading && !hasActivity && !hasProviders && (
-        <Card className="p-6 text-center">
-          <p className="text-sm text-[var(--text-secondary)]">
-            Pick one of the options above to get started. Add a provider key, pull a model, or create an agent.
-          </p>
-        </Card>
-      )}
-
-      {/* Cloud empty state */}
-      {!isLocal && (
+  // Cloud mode — redirect to instances
+  if (!isLocal) {
+    return (
+      <main className="max-w-4xl mx-auto px-4 sm:px-6 py-8">
         <Card className="p-6 text-center">
           <p className="text-sm text-[var(--text-secondary)]">
             Connect a Solon instance or deploy a managed server to get started.
           </p>
+        </Card>
+      </main>
+    )
+  }
+
+  return (
+    <main className="max-w-4xl mx-auto px-4 sm:px-6 py-8 space-y-6">
+      {/* Greeting + Status */}
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight text-[var(--text)]">
+          {getGreeting()}{name ? `, ${name}` : ''}.
+        </h1>
+        <div className="mt-1 flex items-center gap-2">
+          <span className={`w-2 h-2 rounded-full ${isOnline ? 'bg-green-500' : 'bg-red-500'}`} />
+          <span className="text-sm text-[var(--text-tertiary)]">
+            {isOnline ? 'Solon is running' : 'Solon is offline'}
+            {version ? ` · v${version}` : ''}
+          </span>
+        </div>
+      </div>
+
+      {/* Agent Status Hero */}
+      <Card className="p-6">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <div className={`w-10 h-10 rounded-full flex items-center justify-center text-xl ${
+              isRunning ? 'bg-green-500/10' : 'bg-[var(--bg-hover)]'
+            }`}>
+              {isRunning ? '🦞' : '○'}
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold text-[var(--text)]">
+                {isRunning ? 'Your Agent is running' : 'Start your Agent'}
+              </h2>
+              <p className="text-sm text-[var(--text-tertiary)]">
+                {isRunning
+                  ? `${sessions[0]?.model || 'claude-opus-4-6'} · ${sessions.length} session${sessions.length !== 1 ? 's' : ''}`
+                  : 'AI agent with tools, browser, and code execution'
+                }
+              </p>
+            </div>
+          </div>
+          <div className="flex items-center gap-3">
+            {isRunning && (
+              <span className="flex items-center gap-1.5 text-xs text-green-400">
+                <span className="w-2 h-2 rounded-full bg-green-400 animate-pulse" />
+                Running
+              </span>
+            )}
+            {!isRunning && (
+              <button onClick={handleLaunch} disabled={launching}
+                className="px-5 py-2.5 rounded-lg text-sm font-medium bg-green-600 text-white hover:bg-green-500 transition-colors disabled:opacity-50">
+                {launching ? 'Starting...' : 'Launch Agent'}
+              </button>
+            )}
+          </div>
+        </div>
+        {error && <p className="mt-3 text-xs text-red-400">{error}</p>}
+        {launching && (
+          <div className="mt-4 flex items-center gap-2 text-sm text-yellow-400">
+            <span className="w-2 h-2 rounded-full bg-yellow-400 animate-pulse" />
+            Pulling image and starting container... This may take a minute on first run.
+          </div>
+        )}
+      </Card>
+
+      {/* Action Cards — only when agent is running */}
+      {isRunning && (
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <button onClick={() => navigate('/chat')}
+            className="text-left p-5 rounded-xl border border-[var(--border)] bg-[var(--bg-card)] hover:border-green-500/30 transition-colors">
+            <div className="text-2xl mb-2">💬</div>
+            <h3 className="text-sm font-semibold text-[var(--text)]">Chat</h3>
+            <p className="text-xs text-[var(--text-tertiary)] mt-1">Quick conversation with your agent</p>
+          </button>
+          <button onClick={() => window.open('/api/v1/openclaw/ui', '_blank')}
+            className="text-left p-5 rounded-xl border border-[var(--border)] bg-[var(--bg-card)] hover:border-orange-500/30 transition-colors">
+            <div className="text-2xl mb-2">🦞</div>
+            <h3 className="text-sm font-semibold text-[var(--text)]">OpenClaw UI</h3>
+            <p className="text-xs text-[var(--text-tertiary)] mt-1">Full control panel in a new tab</p>
+          </button>
+          <button onClick={() => navigate('/settings')}
+            className="text-left p-5 rounded-xl border border-[var(--border)] bg-[var(--bg-card)] hover:border-blue-500/30 transition-colors">
+            <div className="text-2xl mb-2">📱</div>
+            <h3 className="text-sm font-semibold text-[var(--text)]">Channels</h3>
+            <p className="text-xs text-[var(--text-tertiary)] mt-1">Telegram, WhatsApp, Discord</p>
+          </button>
+        </div>
+      )}
+
+      {/* Quick Chat — inline */}
+      {isRunning && (
+        <Card className="p-5">
+          <h3 className="text-xs font-medium uppercase tracking-wider text-[var(--text-tertiary)] mb-3">Quick Message</h3>
+          <div className="flex gap-2">
+            <input
+              value={quickMsg}
+              onChange={e => setQuickMsg(e.target.value)}
+              onKeyDown={e => e.key === 'Enter' && handleQuickSend()}
+              placeholder="Ask your agent anything..."
+              className="flex-1 px-3 py-2 rounded-lg border border-[var(--border)] bg-[var(--bg)] text-[var(--text)] text-sm focus:outline-none focus:border-[var(--accent)]"
+              disabled={quickSending}
+            />
+            <button onClick={handleQuickSend} disabled={!quickMsg.trim() || quickSending}
+              className="px-4 py-2 rounded-lg text-sm font-medium bg-[var(--accent)] text-white hover:opacity-90 transition-opacity disabled:opacity-30">
+              {quickSending ? '...' : 'Send'}
+            </button>
+          </div>
+          {quickReply && (
+            <div className="mt-3 p-3 rounded-lg bg-[var(--bg)] text-sm text-[var(--text)] whitespace-pre-wrap">
+              {quickReply}
+            </div>
+          )}
+          <p className="mt-2 text-xs text-[var(--text-tertiary)]">
+            For full conversations, <button onClick={() => navigate('/chat')} className="text-[var(--accent)] hover:underline">open Chat</button>
+          </p>
+        </Card>
+      )}
+
+      {/* Recent Sessions */}
+      {isRunning && sessions.length > 0 && (
+        <Card className="p-5">
+          <h3 className="text-xs font-medium uppercase tracking-wider text-[var(--text-tertiary)] mb-3">Recent Conversations</h3>
+          <div className="space-y-2">
+            {sessions.slice(0, 5).map(s => (
+              <button key={s.sessionId} onClick={() => navigate('/chat')}
+                className="w-full text-left flex items-center justify-between px-3 py-2 rounded-lg hover:bg-[var(--bg-hover)] transition-colors">
+                <div>
+                  <span className="text-sm text-[var(--text)]">{s.key.replace('agent:main:', '')}</span>
+                  <span className="ml-2 text-xs text-[var(--text-tertiary)]">{s.model}</span>
+                </div>
+                <div className="text-xs text-[var(--text-tertiary)]">
+                  {formatNumber(s.totalTokens)} tokens · {timeAgo(s.updatedAt)}
+                </div>
+              </button>
+            ))}
+          </div>
+        </Card>
+      )}
+
+      {/* Stats */}
+      {stats && stats.total_requests > 0 && (
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+          <Card className="p-4">
+            <p className="text-xs text-[var(--text-tertiary)]">Requests Today</p>
+            <p className="text-xl font-bold text-[var(--text)]">{formatNumber(stats.requests_today)}</p>
+          </Card>
+          <Card className="p-4">
+            <p className="text-xs text-[var(--text-tertiary)]">Total Tokens</p>
+            <p className="text-xl font-bold text-[var(--text)]">{formatNumber(stats.total_tokens_in + stats.total_tokens_out)}</p>
+          </Card>
+          <Card className="p-4">
+            <p className="text-xs text-[var(--text-tertiary)]">Avg Latency</p>
+            <p className="text-xl font-bold text-[var(--text)]">{stats.avg_latency_ms > 0 ? `${Math.round(stats.avg_latency_ms)}ms` : '--'}</p>
+          </Card>
+          <Card className="p-4">
+            <p className="text-xs text-[var(--text-tertiary)]">Model</p>
+            <p className="text-xl font-bold text-[var(--text)]">{stats.most_used_model || '--'}</p>
+          </Card>
+        </div>
+      )}
+
+      {/* Access Methods — always visible when running */}
+      {isRunning && (
+        <Card className="p-5">
+          <h3 className="text-xs font-medium uppercase tracking-wider text-[var(--text-tertiary)] mb-3">Access Your Agent</h3>
+          <div className="space-y-2 text-sm">
+            <div className="flex items-center justify-between py-1">
+              <span className="text-[var(--text-secondary)]">🌐 Web Chat</span>
+              <button onClick={() => navigate('/chat')} className="text-[var(--accent)] hover:underline text-xs">Open</button>
+            </div>
+            <div className="flex items-center justify-between py-1">
+              <span className="text-[var(--text-secondary)]">🦞 OpenClaw UI</span>
+              <button onClick={() => window.open('/api/v1/openclaw/ui', '_blank')} className="text-[var(--accent)] hover:underline text-xs">Open in new tab</button>
+            </div>
+            <div className="flex items-center justify-between py-1">
+              <span className="text-[var(--text-secondary)]">💻 Terminal</span>
+              <code className="text-xs text-[var(--text-tertiary)] bg-[var(--bg-code)] px-2 py-0.5 rounded">
+                ssh root@{window.location.hostname} → openclaw tui
+              </code>
+            </div>
+            <div className="flex items-center justify-between py-1">
+              <span className="text-[var(--text-secondary)]">🔌 API</span>
+              <code className="text-xs text-[var(--text-tertiary)] bg-[var(--bg-code)] px-2 py-0.5 rounded">
+                POST /api/v1/openclaw/send
+              </code>
+            </div>
+          </div>
+        </Card>
+      )}
+
+      {/* Empty state for new users without agent */}
+      {!isRunning && !launching && agentStatus?.available === false && (
+        <Card className="p-6 text-center">
+          <p className="text-sm text-[var(--text-secondary)]">
+            Install Docker to enable the full agent experience, or use the direct chat with a local or cloud model.
+          </p>
+          <button onClick={() => navigate('/chat')} className="mt-3 text-sm text-[var(--accent)] hover:underline">
+            Go to Chat →
+          </button>
         </Card>
       )}
     </main>

--- a/dashboard/src/pages/instance/AgentSettings.tsx
+++ b/dashboard/src/pages/instance/AgentSettings.tsx
@@ -138,8 +138,9 @@ export default function AgentSettings() {
         body: JSON.stringify({ channel: 'telegram', bot_token: botToken.trim() }),
       })
       if (!res.ok) {
-        const err = await res.json().catch(() => ({ error: res.statusText }))
-        throw new Error((err as { error?: string }).error || res.statusText)
+        const err = await res.json().catch(() => ({ error: res.statusText })) as Record<string, unknown>
+        const msg = typeof err.error === 'string' ? err.error : (err.error as Record<string, unknown>)?.message as string || res.statusText
+        throw new Error(msg)
       }
       setBotToken('')
       setShowTelegramForm(false)

--- a/dashboard/src/pages/instance/AgentSettings.tsx
+++ b/dashboard/src/pages/instance/AgentSettings.tsx
@@ -17,7 +17,8 @@ interface Channel {
   name: string
   type: string
   status: string
-  username: string
+  username?: string
+  lastError?: string
 }
 
 interface Skill {
@@ -67,6 +68,7 @@ export default function AgentSettings() {
   const [botToken, setBotToken] = useState('')
   const [connecting, setConnecting] = useState(false)
   const [connectError, setConnectError] = useState('')
+  const [connectSuccess, setConnectSuccess] = useState('')
 
   // Workspace tab state
   const [selectedFile, setSelectedFile] = useState('SOUL.md')
@@ -131,6 +133,7 @@ export default function AgentSettings() {
     if (!botToken.trim()) return
     setConnecting(true)
     setConnectError('')
+    setConnectSuccess('')
     try {
       const res = await fetch('/api/v1/openclaw/channels', {
         method: 'POST',
@@ -144,6 +147,7 @@ export default function AgentSettings() {
       }
       setBotToken('')
       setShowTelegramForm(false)
+      setConnectSuccess('Channel added. Check the status above — the gateway may need a moment to connect.')
       await loadChannels()
     } catch (e: unknown) {
       setConnectError((e as Error).message)
@@ -281,6 +285,9 @@ export default function AgentSettings() {
                             <p className="text-xs text-[var(--text-tertiary)]">
                               {ch.type}{ch.username ? ` · @${ch.username}` : ''}
                             </p>
+                            {ch.lastError && (
+                              <p className="text-xs text-[var(--red)] mt-0.5">{ch.lastError}</p>
+                            )}
                           </div>
                         </div>
                         <div className="flex items-center gap-3">
@@ -361,6 +368,9 @@ export default function AgentSettings() {
                       <p className="text-xs text-[var(--red)]">{connectError}</p>
                     )}
                   </div>
+                )}
+                {connectSuccess && (
+                  <p className="text-xs text-green-400">{connectSuccess}</p>
                 )}
               </Card>
             </div>

--- a/dashboard/src/pages/instance/AgentSettings.tsx
+++ b/dashboard/src/pages/instance/AgentSettings.tsx
@@ -1,0 +1,519 @@
+import { useState, useEffect, useCallback } from 'react'
+import { fetchJSON, getLocalApiKey, isNonLocalhost } from '../../api/client'
+import Card from '../../components/Card'
+
+function authHeaders(): Record<string, string> {
+  const apiKey = isNonLocalhost() ? getLocalApiKey() : null
+  return apiKey ? { Authorization: `Bearer ${apiKey}` } : {}
+}
+
+interface Agent {
+  name: string
+  model: string
+  modelProvider: string
+}
+
+interface Channel {
+  name: string
+  type: string
+  status: string
+  username: string
+}
+
+interface Skill {
+  name: string
+  description: string
+  enabled: boolean
+}
+
+type Tab = 'model' | 'channels' | 'workspace' | 'skills' | 'access'
+
+const TABS: { id: Tab; label: string }[] = [
+  { id: 'model', label: 'Model' },
+  { id: 'channels', label: 'Channels' },
+  { id: 'workspace', label: 'Workspace' },
+  { id: 'skills', label: 'Skills' },
+  { id: 'access', label: 'Access' },
+]
+
+const WORKSPACE_FILES: { name: string; description: string }[] = [
+  { name: 'SOUL.md', description: 'Core personality, values, and behavioral principles of your agent.' },
+  { name: 'IDENTITY.md', description: 'Agent name, role, and self-description presented to users.' },
+  { name: 'USER.md', description: 'Information about the user — their preferences, context, and goals.' },
+  { name: 'AGENTS.md', description: 'Other agents in the network and how to collaborate with them.' },
+]
+
+function channelIcon(type: string): string {
+  switch (type.toLowerCase()) {
+    case 'telegram': return '📱'
+    case 'whatsapp': return '💬'
+    case 'discord': return '🎮'
+    default: return '🔌'
+  }
+}
+
+export default function AgentSettings() {
+  const [activeTab, setActiveTab] = useState<Tab>('model')
+
+  // Data state
+  const [agents, setAgents] = useState<Agent[]>([])
+  const [channels, setChannels] = useState<Channel[]>([])
+  const [skills, setSkills] = useState<Skill[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  // Channels tab state
+  const [showTelegramForm, setShowTelegramForm] = useState(false)
+  const [botToken, setBotToken] = useState('')
+  const [connecting, setConnecting] = useState(false)
+  const [connectError, setConnectError] = useState('')
+
+  // Workspace tab state
+  const [selectedFile, setSelectedFile] = useState('SOUL.md')
+  const [fileContent, setFileContent] = useState('')
+  const [fileLoading, setFileLoading] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [saved, setSaved] = useState(false)
+
+  // Access tab state
+  const [copiedField, setCopiedField] = useState<string | null>(null)
+
+  const loadChannels = useCallback(async () => {
+    try {
+      const data = await fetchJSON<{ channels: Channel[] }>('/api/v1/openclaw/channels')
+      setChannels(data.channels || [])
+    } catch {
+      // non-fatal
+    }
+  }, [])
+
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true)
+      setError('')
+      try {
+        const [agentsData, channelsData, skillsData] = await Promise.all([
+          fetchJSON<{ agents: Agent[] }>('/api/v1/openclaw/agents').catch(() => ({ agents: [] })),
+          fetchJSON<{ channels: Channel[] }>('/api/v1/openclaw/channels').catch(() => ({ channels: [] })),
+          fetchJSON<{ skills: Skill[] }>('/api/v1/openclaw/skills').catch(() => ({ skills: [] })),
+        ])
+        setAgents(agentsData.agents || [])
+        setChannels(channelsData.channels || [])
+        setSkills(skillsData.skills || [])
+      } catch (e: unknown) {
+        setError((e as Error).message)
+      } finally {
+        setLoading(false)
+      }
+    }
+    load()
+  }, [])
+
+  useEffect(() => {
+    if (activeTab !== 'workspace') return
+    const load = async () => {
+      setFileLoading(true)
+      try {
+        const data = await fetchJSON<{ filename: string; content: string }>(
+          `/api/v1/openclaw/workspace/${selectedFile}`
+        )
+        setFileContent(data.content || '')
+      } catch {
+        setFileContent('')
+      } finally {
+        setFileLoading(false)
+      }
+    }
+    load()
+  }, [activeTab, selectedFile])
+
+  const handleConnect = async () => {
+    if (!botToken.trim()) return
+    setConnecting(true)
+    setConnectError('')
+    try {
+      const res = await fetch('/api/v1/openclaw/channels', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeaders() },
+        body: JSON.stringify({ channel: 'telegram', bot_token: botToken.trim() }),
+      })
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({ error: res.statusText }))
+        throw new Error((err as { error?: string }).error || res.statusText)
+      }
+      setBotToken('')
+      setShowTelegramForm(false)
+      await loadChannels()
+    } catch (e: unknown) {
+      setConnectError((e as Error).message)
+    } finally {
+      setConnecting(false)
+    }
+  }
+
+  const handleDisconnect = async (name: string) => {
+    try {
+      await fetch(`/api/v1/openclaw/channels/${encodeURIComponent(name)}`, {
+        method: 'DELETE',
+        headers: authHeaders(),
+      })
+      await loadChannels()
+    } catch {
+      // silently fail — reload will reflect truth
+    }
+  }
+
+  const handleSaveWorkspace = async () => {
+    setSaving(true)
+    try {
+      await fetch(`/api/v1/openclaw/workspace/${selectedFile}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', ...authHeaders() },
+        body: JSON.stringify({ content: fileContent }),
+      })
+      setSaved(true)
+      setTimeout(() => setSaved(false), 2000)
+    } catch {
+      // silently fail
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const copyToClipboard = async (value: string, field: string) => {
+    try {
+      await navigator.clipboard.writeText(value)
+    } catch {
+      const ta = document.createElement('textarea')
+      ta.value = value
+      document.body.appendChild(ta)
+      ta.select()
+      document.execCommand('copy')
+      document.body.removeChild(ta)
+    }
+    setCopiedField(field)
+    setTimeout(() => setCopiedField(null), 2000)
+  }
+
+  const agent = agents[0]
+  const host = window.location.host
+  const origin = window.location.origin
+
+  return (
+    <main className="max-w-3xl mx-auto px-4 sm:px-6 py-8">
+      <h1 className="text-2xl font-bold tracking-tight text-[var(--text)] mb-6">Agent Settings</h1>
+
+      {error && (
+        <div className="rounded-lg bg-[var(--bg-error)] px-4 py-3 text-sm text-[var(--red)] mb-6">
+          {error}
+        </div>
+      )}
+
+      {/* Tab bar */}
+      <div className="flex gap-1 border-b border-[var(--border)] mb-6">
+        {TABS.map(tab => (
+          <button
+            key={tab.id}
+            onClick={() => setActiveTab(tab.id)}
+            className={`px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px ${
+              activeTab === tab.id
+                ? 'border-[var(--accent)] text-[var(--text)]'
+                : 'border-transparent text-[var(--text-secondary)] hover:text-[var(--text)]'
+            }`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {loading ? (
+        <div className="text-sm text-[var(--text-tertiary)] animate-pulse">Loading...</div>
+      ) : (
+        <>
+          {/* Model tab */}
+          {activeTab === 'model' && (
+            <Card className="p-6">
+              <h3 className="text-base font-semibold text-[var(--text)] mb-4">Current Model</h3>
+              {agent ? (
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between py-2 border-b border-[var(--border)]">
+                    <span className="text-sm text-[var(--text-tertiary)]">Agent</span>
+                    <span className="text-sm font-medium text-[var(--text)]">{agent.name}</span>
+                  </div>
+                  <div className="flex items-center justify-between py-2 border-b border-[var(--border)]">
+                    <span className="text-sm text-[var(--text-tertiary)]">Model</span>
+                    <span className="text-sm font-medium text-[var(--text)]">{agent.model}</span>
+                  </div>
+                  <div className="flex items-center justify-between py-2">
+                    <span className="text-sm text-[var(--text-tertiary)]">Provider</span>
+                    <span className="text-sm font-medium text-[var(--text)]">{agent.modelProvider}</span>
+                  </div>
+                </div>
+              ) : (
+                <p className="text-sm text-[var(--text-secondary)]">No agent found.</p>
+              )}
+              <p className="mt-4 text-xs text-[var(--text-tertiary)]">
+                To change the model, edit the AGENTS.md file in the Workspace tab.
+              </p>
+            </Card>
+          )}
+
+          {/* Channels tab */}
+          {activeTab === 'channels' && (
+            <div className="space-y-6">
+              {/* Connected channels */}
+              <Card className="p-6">
+                <h3 className="text-base font-semibold text-[var(--text)] mb-4">Connected Channels</h3>
+                {channels.length === 0 ? (
+                  <p className="text-sm text-[var(--text-secondary)]">No channels connected yet.</p>
+                ) : (
+                  <div className="space-y-2">
+                    {channels.map(ch => (
+                      <div
+                        key={ch.name}
+                        className="flex items-center justify-between py-3 border-b border-[var(--border)] last:border-0"
+                      >
+                        <div className="flex items-center gap-3">
+                          <span className="text-lg">{channelIcon(ch.type)}</span>
+                          <div>
+                            <p className="text-sm font-medium text-[var(--text)]">{ch.name}</p>
+                            <p className="text-xs text-[var(--text-tertiary)]">
+                              {ch.type}{ch.username ? ` · @${ch.username}` : ''}
+                            </p>
+                          </div>
+                        </div>
+                        <div className="flex items-center gap-3">
+                          <span className="flex items-center gap-1.5 text-xs">
+                            <span
+                              className={`w-2 h-2 rounded-full ${
+                                ch.status === 'connected' ? 'bg-green-400' : 'bg-yellow-400'
+                              }`}
+                            />
+                            <span className="text-[var(--text-tertiary)]">{ch.status}</span>
+                          </span>
+                          <button
+                            onClick={() => handleDisconnect(ch.name)}
+                            className="text-xs text-[var(--red)] hover:underline"
+                          >
+                            Disconnect
+                          </button>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </Card>
+
+              {/* Connect a channel */}
+              <Card className="p-6">
+                <h3 className="text-base font-semibold text-[var(--text)] mb-4">Connect a Channel</h3>
+                <div className="flex gap-2 flex-wrap">
+                  <button
+                    onClick={() => setShowTelegramForm(v => !v)}
+                    className="flex items-center gap-2 px-4 py-2 rounded-lg border border-[var(--border)] text-sm text-[var(--text)] hover:bg-[var(--bg-hover)] transition-colors"
+                  >
+                    <span>📱</span> Telegram
+                  </button>
+                  <button
+                    disabled
+                    className="flex items-center gap-2 px-4 py-2 rounded-lg border border-[var(--border)] text-sm text-[var(--text-tertiary)] opacity-50 cursor-not-allowed"
+                    title="Coming soon"
+                  >
+                    <span>💬</span> WhatsApp <span className="text-[10px] text-[var(--text-tertiary)]">soon</span>
+                  </button>
+                  <button
+                    disabled
+                    className="flex items-center gap-2 px-4 py-2 rounded-lg border border-[var(--border)] text-sm text-[var(--text-tertiary)] opacity-50 cursor-not-allowed"
+                    title="Coming soon"
+                  >
+                    <span>🎮</span> Discord <span className="text-[10px] text-[var(--text-tertiary)]">soon</span>
+                  </button>
+                </div>
+
+                {showTelegramForm && (
+                  <div className="mt-4 space-y-3">
+                    <div className="rounded-lg bg-[var(--bg-hover)] px-4 py-3 text-sm text-[var(--text-secondary)]">
+                      <p className="font-medium text-[var(--text)] mb-1">Setup instructions</p>
+                      <ol className="list-decimal list-inside space-y-1 text-xs">
+                        <li>Open Telegram and search for <span className="font-mono">@BotFather</span></li>
+                        <li>Send <span className="font-mono">/newbot</span> and follow the prompts</li>
+                        <li>Copy the bot token and paste it below</li>
+                      </ol>
+                    </div>
+                    <div className="flex gap-2">
+                      <input
+                        type="text"
+                        value={botToken}
+                        onChange={e => setBotToken(e.target.value)}
+                        placeholder="1234567890:ABCDefgh..."
+                        className="flex-1 px-3 py-2 rounded-lg border border-[var(--border)] bg-[var(--bg)] text-sm text-[var(--text)] placeholder-[var(--text-tertiary)] focus:outline-none focus:border-[var(--accent)]"
+                      />
+                      <button
+                        onClick={handleConnect}
+                        disabled={connecting || !botToken.trim()}
+                        className="px-4 py-2 rounded-lg bg-[var(--accent)] text-white text-sm font-medium hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed transition-opacity"
+                      >
+                        {connecting ? 'Connecting...' : 'Connect'}
+                      </button>
+                    </div>
+                    {connectError && (
+                      <p className="text-xs text-[var(--red)]">{connectError}</p>
+                    )}
+                  </div>
+                )}
+              </Card>
+            </div>
+          )}
+
+          {/* Workspace tab */}
+          {activeTab === 'workspace' && (
+            <Card className="p-6">
+              <h3 className="text-base font-semibold text-[var(--text)] mb-4">Workspace Files</h3>
+
+              {/* File selector */}
+              <div className="flex gap-2 flex-wrap mb-2">
+                {WORKSPACE_FILES.map(f => (
+                  <button
+                    key={f.name}
+                    onClick={() => setSelectedFile(f.name)}
+                    className={`px-3 py-1.5 rounded-lg text-sm font-mono transition-colors border ${
+                      selectedFile === f.name
+                        ? 'bg-[var(--accent)] text-white border-[var(--accent)]'
+                        : 'border-[var(--border)] text-[var(--text-secondary)] hover:text-[var(--text)] hover:bg-[var(--bg-hover)]'
+                    }`}
+                  >
+                    {f.name}
+                  </button>
+                ))}
+              </div>
+
+              {/* File description */}
+              {WORKSPACE_FILES.find(f => f.name === selectedFile) && (
+                <p className="text-xs text-[var(--text-tertiary)] mb-3">
+                  {WORKSPACE_FILES.find(f => f.name === selectedFile)!.description}
+                </p>
+              )}
+
+              {/* Editor */}
+              {fileLoading ? (
+                <div className="h-64 flex items-center justify-center text-sm text-[var(--text-tertiary)] animate-pulse">
+                  Loading...
+                </div>
+              ) : (
+                <textarea
+                  value={fileContent}
+                  onChange={e => setFileContent(e.target.value)}
+                  className="w-full h-64 px-3 py-2 rounded-lg border border-[var(--border)] bg-[var(--bg)] text-sm font-mono text-[var(--text)] placeholder-[var(--text-tertiary)] focus:outline-none focus:border-[var(--accent)] resize-y"
+                  placeholder={`# ${selectedFile}\n\nStart writing...`}
+                />
+              )}
+
+              <div className="flex items-center justify-between mt-3">
+                <span className={`text-xs text-green-400 transition-opacity ${saved ? 'opacity-100' : 'opacity-0'}`}>
+                  Saved
+                </span>
+                <button
+                  onClick={handleSaveWorkspace}
+                  disabled={saving || fileLoading}
+                  className="px-4 py-2 rounded-lg bg-[var(--accent)] text-white text-sm font-medium hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed transition-opacity"
+                >
+                  {saving ? 'Saving...' : 'Save'}
+                </button>
+              </div>
+            </Card>
+          )}
+
+          {/* Skills tab */}
+          {activeTab === 'skills' && (
+            <Card className="p-6">
+              <h3 className="text-base font-semibold text-[var(--text)] mb-4">Skills</h3>
+              {skills.length === 0 ? (
+                <p className="text-sm text-[var(--text-secondary)]">No skills available.</p>
+              ) : (
+                <div className="space-y-2">
+                  {skills.map(skill => (
+                    <div
+                      key={skill.name}
+                      className="flex items-start justify-between py-3 border-b border-[var(--border)] last:border-0"
+                    >
+                      <div className="flex-1 min-w-0 pr-4">
+                        <p className="text-sm font-medium text-[var(--text)]">{skill.name}</p>
+                        {skill.description && (
+                          <p className="text-xs text-[var(--text-tertiary)] mt-0.5">{skill.description}</p>
+                        )}
+                      </div>
+                      <span
+                        className={`shrink-0 text-xs font-medium px-2 py-0.5 rounded-full ${
+                          skill.enabled
+                            ? 'bg-green-500/10 text-green-500'
+                            : 'bg-[var(--bg-hover)] text-[var(--text-tertiary)]'
+                        }`}
+                      >
+                        {skill.enabled ? 'Active' : 'Inactive'}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </Card>
+          )}
+
+          {/* Access tab */}
+          {activeTab === 'access' && (
+            <Card className="p-6">
+              <h3 className="text-base font-semibold text-[var(--text)] mb-4">Access</h3>
+              <div className="space-y-4">
+                {[
+                  {
+                    label: 'SSH',
+                    field: 'ssh',
+                    value: `ssh user@${host}`,
+                    hint: 'Direct SSH access to the host',
+                  },
+                  {
+                    label: 'TUI Command',
+                    field: 'tui',
+                    value: `openclaw tui --host ${origin}`,
+                    hint: 'Run the OpenClaw terminal interface',
+                  },
+                  {
+                    label: 'API Endpoint',
+                    field: 'api',
+                    value: `${origin}/v1`,
+                    hint: 'OpenAI-compatible inference API',
+                  },
+                  {
+                    label: 'OpenClaw UI',
+                    field: 'ui',
+                    value: `${origin}/api/v1/openclaw/ui`,
+                    hint: 'OpenClaw web control panel',
+                  },
+                ].map(item => (
+                  <div key={item.field}>
+                    <div className="flex items-center justify-between mb-1">
+                      <span className="text-xs font-medium text-[var(--text-tertiary)] uppercase tracking-wider">
+                        {item.label}
+                      </span>
+                      <button
+                        onClick={() => copyToClipboard(item.value, item.field)}
+                        className="text-xs text-[var(--accent)] hover:underline"
+                      >
+                        {copiedField === item.field ? 'Copied!' : 'Copy'}
+                      </button>
+                    </div>
+                    <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-[var(--bg)] border border-[var(--border)]">
+                      <span className="text-sm font-mono text-[var(--text)] truncate flex-1">{item.value}</span>
+                    </div>
+                    {item.hint && (
+                      <p className="text-xs text-[var(--text-tertiary)] mt-1">{item.hint}</p>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </Card>
+          )}
+        </>
+      )}
+    </main>
+  )
+}

--- a/dashboard/src/pages/instance/Chat.tsx
+++ b/dashboard/src/pages/instance/Chat.tsx
@@ -127,7 +127,7 @@ export default function Chat() {
     const text = input.trim()
     if (!text || sending) return
     setInput('')
-    setMessages(prev => [...prev, { id: crypto.randomUUID(), role: 'user', content: text, timestamp: Date.now() }])
+    setMessages(prev => [...prev, { id: Math.random().toString(36).slice(2) + Date.now().toString(36), role: 'user', content: text, timestamp: Date.now() }])
 
     if (mode === 'agent') {
       await sendViaAgent(text)
@@ -138,7 +138,7 @@ export default function Chat() {
 
   async function sendViaAgent(text: string) {
     setSending(true)
-    const id = crypto.randomUUID()
+    const id = Math.random().toString(36).slice(2) + Date.now().toString(36)
     setMessages(prev => [...prev, { id, role: 'assistant', content: '', timestamp: Date.now(), isStreaming: true }])
 
     try {
@@ -213,7 +213,7 @@ export default function Chat() {
   async function sendViaSSE(text: string) {
     if (!selectedModel) { setError('No model selected'); return }
     setSending(true)
-    const id = crypto.randomUUID()
+    const id = Math.random().toString(36).slice(2) + Date.now().toString(36)
     setMessages(prev => [...prev, { id, role: 'assistant', content: '', timestamp: Date.now(), isStreaming: true }])
 
     try {
@@ -290,7 +290,7 @@ export default function Chat() {
                   onClick={() => {
                     setActiveSession(s.sessionId)
                     setMessages([{
-                      id: crypto.randomUUID(),
+                      id: Math.random().toString(36).slice(2) + Date.now().toString(36),
                       role: 'system',
                       content: `Resumed session: ${s.key.replace('agent:main:', '') || s.sessionId}\nModel: ${s.model} · ${formatTokens(s.totalTokens)} tokens\n\nPrevious messages are not loaded yet — new messages will continue this session.`,
                       timestamp: Date.now(),

--- a/dashboard/src/pages/instance/Chat.tsx
+++ b/dashboard/src/pages/instance/Chat.tsx
@@ -54,6 +54,9 @@ export default function Chat() {
   const [sessions, setSessions] = useState<SessionInfo[]>([])
   const [sidebarOpen, setSidebarOpen] = useState(true)
   const [activeSession, setActiveSession] = useState<string | null>(null)
+  const [agentList, setAgentList] = useState<{ name: string }[]>([])
+  const [selectedAgent, setSelectedAgent] = useState('main')
+  const [thinkingLevel, setThinkingLevel] = useState<'off' | 'low' | 'medium' | 'high'>('medium')
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLTextAreaElement>(null)
 
@@ -115,6 +118,9 @@ export default function Chat() {
   useEffect(() => {
     connect()
     loadSessions()
+    fetchJSON<{ agents?: { name: string }[] }>('/api/v1/openclaw/agents')
+      .then(d => setAgentList(d.agents || []))
+      .catch(() => {})
   }, [])
 
   async function handleSend() {
@@ -139,7 +145,7 @@ export default function Chat() {
       const resp = await fetch('/api/v1/openclaw/send', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...authHeaders() },
-        body: JSON.stringify({ message: text }),
+        body: JSON.stringify({ message: text, agent: selectedAgent, thinking: thinkingLevel }),
       })
       if (!resp.ok) {
         const err = await resp.json().catch(() => ({ error: { message: resp.statusText } }))
@@ -321,6 +327,25 @@ export default function Chat() {
               <select value={selectedModel} onChange={e => setSelectedModel(e.target.value)}
                 className="text-xs px-2 py-1 rounded border border-[var(--border)] bg-[var(--bg)] text-[var(--text)]">
                 {models.map(m => <option key={m.name} value={m.name}>{m.name}</option>)}
+              </select>
+            )}
+
+            {/* Agent selector — only in agent mode with multiple agents */}
+            {mode === 'agent' && agentList.length > 1 && (
+              <select value={selectedAgent} onChange={e => setSelectedAgent(e.target.value)}
+                className="text-xs px-2 py-1 rounded border border-[var(--border)] bg-[var(--bg)] text-[var(--text)]">
+                {agentList.map(a => <option key={a.name} value={a.name}>{a.name}</option>)}
+              </select>
+            )}
+
+            {/* Thinking level — only in agent mode */}
+            {mode === 'agent' && (
+              <select value={thinkingLevel} onChange={e => setThinkingLevel(e.target.value as 'off' | 'low' | 'medium' | 'high')}
+                className="text-xs px-2 py-1 rounded border border-[var(--border)] bg-[var(--bg)] text-[var(--text)]">
+                <option value="off">Thinking: Off</option>
+                <option value="low">Thinking: Low</option>
+                <option value="medium">Thinking: Medium</option>
+                <option value="high">Thinking: High</option>
               </select>
             )}
           </div>

--- a/dashboard/src/pages/instance/Chat.tsx
+++ b/dashboard/src/pages/instance/Chat.tsx
@@ -15,7 +15,31 @@ interface ChatMessage {
   isStreaming?: boolean
 }
 
+interface SessionInfo {
+  key: string
+  sessionId: string
+  model: string
+  modelProvider: string
+  totalTokens: number
+  updatedAt: number
+}
+
 type ConnectionMode = 'agent' | 'direct' | 'connecting' | 'disconnected'
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`
+  return String(n)
+}
+
+function timeAgo(timestamp: number): string {
+  const diff = Date.now() - timestamp
+  const mins = Math.floor(diff / 60000)
+  if (mins < 60) return `${mins}m ago`
+  const hours = Math.floor(mins / 60)
+  if (hours < 24) return `${hours}h ago`
+  return `${Math.floor(hours / 24)}d ago`
+}
 
 export default function Chat() {
   const [messages, setMessages] = useState<ChatMessage[]>([])
@@ -27,6 +51,9 @@ export default function Chat() {
   const [sending, setSending] = useState(false)
   const [starting, setStarting] = useState(false)
   const [dockerAvailable, setDockerAvailable] = useState(true)
+  const [sessions, setSessions] = useState<SessionInfo[]>([])
+  const [sidebarOpen, setSidebarOpen] = useState(true)
+  const [activeSession, setActiveSession] = useState<string | null>(null)
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLTextAreaElement>(null)
 
@@ -58,6 +85,13 @@ export default function Chat() {
     }
   }, [selectedModel])
 
+  const loadSessions = useCallback(async () => {
+    try {
+      const d = await fetchJSON<{ sessions?: SessionInfo[] }>('/api/v1/openclaw/sessions')
+      setSessions(d.sessions || [])
+    } catch { /* */ }
+  }, [])
+
   async function handleStartAgent() {
     setStarting(true)
     setError('')
@@ -78,7 +112,10 @@ export default function Chat() {
     }
   }
 
-  useEffect(() => { connect() }, [])
+  useEffect(() => {
+    connect()
+    loadSessions()
+  }, [])
 
   async function handleSend() {
     const text = input.trim()
@@ -228,105 +265,149 @@ export default function Chat() {
   const dotColor = { agent: 'bg-green-400', direct: 'bg-blue-400', connecting: 'bg-yellow-400 animate-pulse', disconnected: 'bg-red-400' }[mode]
 
   return (
-    <div className="flex flex-col h-[calc(100vh-3.5rem)]">
-      {/* Header */}
-      <div className="flex items-center justify-between px-4 py-2 border-b border-[var(--border)] bg-[var(--bg-card)]">
-        <div className="flex items-center gap-3">
-          <h1 className="text-sm font-semibold text-[var(--text)]">Chat</h1>
-          <span className={`flex items-center gap-1.5 text-xs ${modeColor}`}>
-            <span className={`w-1.5 h-1.5 rounded-full ${dotColor}`} />
-            {modeLabel}
-          </span>
-          {mode === 'direct' && models.length > 0 && (
-            <select value={selectedModel} onChange={e => setSelectedModel(e.target.value)}
-              className="text-xs px-2 py-1 rounded border border-[var(--border)] bg-[var(--bg)] text-[var(--text)]">
-              {models.map(m => <option key={m.name} value={m.name}>{m.name}</option>)}
-            </select>
-          )}
-        </div>
-        <div className="flex items-center gap-2">
-          {mode !== 'agent' && dockerAvailable && !starting && (
-            <button onClick={handleStartAgent}
-              className="text-xs px-3 py-1 rounded-md bg-green-600 text-white hover:bg-green-500 transition-colors">
-              Start Agent
-            </button>
-          )}
-          {starting && <span className="text-xs text-yellow-400 animate-pulse">Starting agent...</span>}
-          {mode === 'disconnected' && <button onClick={connect} className="text-xs text-[var(--accent)] hover:underline">Reconnect</button>}
-          {messages.length > 0 && <button onClick={() => setMessages([])} className="text-xs text-[var(--text-tertiary)] hover:text-[var(--text)]">Clear</button>}
-        </div>
-      </div>
-
-      {error && (
-        <div className="px-4 py-2 bg-red-500/10 text-red-400 text-xs flex items-center justify-between">
-          <span>{error}</span>
-          <button onClick={() => setError('')} className="underline">dismiss</button>
+    <div className="flex h-[calc(100vh-3.5rem)]">
+      {/* Sidebar — only in agent mode */}
+      {sidebarOpen && mode === 'agent' && (
+        <div className="w-64 border-r border-[var(--border)] bg-[var(--bg-card)] flex flex-col shrink-0">
+          <div className="flex items-center justify-between px-3 py-2 border-b border-[var(--border)]">
+            <span className="text-xs font-medium text-[var(--text-tertiary)] uppercase tracking-wider">Conversations</span>
+            <button onClick={() => { setActiveSession(null); setMessages([]) }}
+              className="text-xs text-[var(--accent)] hover:underline">New</button>
+          </div>
+          <div className="flex-1 overflow-y-auto">
+            {sessions.length === 0 ? (
+              <p className="px-3 py-4 text-xs text-[var(--text-tertiary)]">No conversations yet</p>
+            ) : (
+              sessions.map(s => (
+                <button
+                  key={s.sessionId}
+                  onClick={() => setActiveSession(s.sessionId)}
+                  className={`w-full text-left px-3 py-2 text-sm transition-colors ${
+                    activeSession === s.sessionId
+                      ? 'bg-[var(--bg-hover)] text-[var(--text)]'
+                      : 'text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]'
+                  }`}
+                >
+                  <p className="truncate text-xs">{s.key.replace('agent:main:', '') || 'Conversation'}</p>
+                  <p className="text-[10px] text-[var(--text-tertiary)] mt-0.5">
+                    {s.model} · {formatTokens(s.totalTokens)} tokens · {timeAgo(s.updatedAt)}
+                  </p>
+                </button>
+              ))
+            )}
+          </div>
         </div>
       )}
 
-      {/* Messages */}
-      <div className="flex-1 overflow-y-auto px-4 py-6 space-y-4">
-        {messages.length === 0 ? (
-          <div className="flex items-center justify-center h-full">
-            <div className="text-center max-w-sm">
-              <p className="text-4xl mb-4">&#x1F99E;</p>
-              <p className="text-[var(--text-secondary)] text-sm">
-                {mode === 'agent' ? 'Connected to OpenClaw agent. Type a message to start.' :
-                 starting ? 'Setting up your agent environment...' :
-                 'Type a message to chat with your AI model.'}
-              </p>
-              {mode !== 'agent' && !starting && dockerAvailable && (
-                <button onClick={handleStartAgent}
-                  className="mt-3 px-4 py-2 rounded-lg text-sm font-medium bg-green-600 text-white hover:bg-green-500 transition-colors">
-                  Launch OpenClaw Agent
-                </button>
-              )}
-              {mode !== 'agent' && !starting && dockerAvailable && (
-                <p className="text-xs text-[var(--text-tertiary)] mt-2">Full agent with tools, code execution, and web browsing.</p>
-              )}
-              {!dockerAvailable && mode !== 'agent' && (
-                <p className="text-xs text-[var(--text-tertiary)] mt-2">Install Docker to enable the full agent experience.</p>
-              )}
-              {starting && (
-                <div className="mt-3 flex items-center gap-2 text-yellow-400 text-sm">
-                  <span className="w-2 h-2 rounded-full bg-yellow-400 animate-pulse" />
-                  Pulling image and starting container... This may take a minute on first run.
-                </div>
-              )}
-            </div>
+      {/* Main chat area */}
+      <div className="flex-1 flex flex-col min-w-0">
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-2 border-b border-[var(--border)] bg-[var(--bg-card)]">
+          <div className="flex items-center gap-3">
+            {mode === 'agent' && (
+              <button onClick={() => setSidebarOpen(!sidebarOpen)}
+                className="p-1 rounded text-[var(--text-tertiary)] hover:text-[var(--text)] hover:bg-[var(--bg-hover)]">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <rect x="3" y="3" width="18" height="18" rx="2" /><line x1="9" y1="3" x2="9" y2="21" />
+                </svg>
+              </button>
+            )}
+            <h1 className="text-sm font-semibold text-[var(--text)]">Chat</h1>
+            <span className={`flex items-center gap-1.5 text-xs ${modeColor}`}>
+              <span className={`w-1.5 h-1.5 rounded-full ${dotColor}`} />
+              {modeLabel}
+            </span>
+            {mode === 'direct' && models.length > 0 && (
+              <select value={selectedModel} onChange={e => setSelectedModel(e.target.value)}
+                className="text-xs px-2 py-1 rounded border border-[var(--border)] bg-[var(--bg)] text-[var(--text)]">
+                {models.map(m => <option key={m.name} value={m.name}>{m.name}</option>)}
+              </select>
+            )}
           </div>
-        ) : (
-          messages.map(msg => (
-            <div key={msg.id} className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}>
-              <div className={`max-w-[80%] rounded-xl px-4 py-2.5 text-sm whitespace-pre-wrap ${
-                msg.role === 'user' ? 'bg-[var(--accent)] text-white rounded-br-sm' : 'bg-[var(--bg-card)] border border-[var(--border)] text-[var(--text)] rounded-bl-sm'
-              }`}>
-                {msg.content || (msg.isStreaming ? (
-                  <span className="inline-flex gap-1">
-                    <span className="w-1.5 h-1.5 rounded-full bg-[var(--text-tertiary)] animate-bounce" style={{ animationDelay: '0ms' }} />
-                    <span className="w-1.5 h-1.5 rounded-full bg-[var(--text-tertiary)] animate-bounce" style={{ animationDelay: '150ms' }} />
-                    <span className="w-1.5 h-1.5 rounded-full bg-[var(--text-tertiary)] animate-bounce" style={{ animationDelay: '300ms' }} />
-                  </span>
-                ) : '')}
+          <div className="flex items-center gap-2">
+            {mode !== 'agent' && dockerAvailable && !starting && (
+              <button onClick={handleStartAgent}
+                className="text-xs px-3 py-1 rounded-md bg-green-600 text-white hover:bg-green-500 transition-colors">
+                Start Agent
+              </button>
+            )}
+            {starting && <span className="text-xs text-yellow-400 animate-pulse">Starting agent...</span>}
+            {mode === 'disconnected' && <button onClick={connect} className="text-xs text-[var(--accent)] hover:underline">Reconnect</button>}
+            {messages.length > 0 && <button onClick={() => setMessages([])} className="text-xs text-[var(--text-tertiary)] hover:text-[var(--text)]">Clear</button>}
+          </div>
+        </div>
+
+        {error && (
+          <div className="px-4 py-2 bg-red-500/10 text-red-400 text-xs flex items-center justify-between">
+            <span>{error}</span>
+            <button onClick={() => setError('')} className="underline">dismiss</button>
+          </div>
+        )}
+
+        {/* Messages */}
+        <div className="flex-1 overflow-y-auto px-4 py-6 space-y-4">
+          {messages.length === 0 ? (
+            <div className="flex items-center justify-center h-full">
+              <div className="text-center max-w-sm">
+                <p className="text-4xl mb-4">&#x1F99E;</p>
+                <p className="text-[var(--text-secondary)] text-sm">
+                  {mode === 'agent' ? 'Connected to OpenClaw agent. Type a message to start.' :
+                   starting ? 'Setting up your agent environment...' :
+                   'Type a message to chat with your AI model.'}
+                </p>
+                {mode !== 'agent' && !starting && dockerAvailable && (
+                  <button onClick={handleStartAgent}
+                    className="mt-3 px-4 py-2 rounded-lg text-sm font-medium bg-green-600 text-white hover:bg-green-500 transition-colors">
+                    Launch OpenClaw Agent
+                  </button>
+                )}
+                {mode !== 'agent' && !starting && dockerAvailable && (
+                  <p className="text-xs text-[var(--text-tertiary)] mt-2">Full agent with tools, code execution, and web browsing.</p>
+                )}
+                {!dockerAvailable && mode !== 'agent' && (
+                  <p className="text-xs text-[var(--text-tertiary)] mt-2">Install Docker to enable the full agent experience.</p>
+                )}
+                {starting && (
+                  <div className="mt-3 flex items-center gap-2 text-yellow-400 text-sm">
+                    <span className="w-2 h-2 rounded-full bg-yellow-400 animate-pulse" />
+                    Pulling image and starting container... This may take a minute on first run.
+                  </div>
+                )}
               </div>
             </div>
-          ))
-        )}
-        <div ref={messagesEndRef} />
-      </div>
+          ) : (
+            messages.map(msg => (
+              <div key={msg.id} className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}>
+                <div className={`max-w-[80%] rounded-xl px-4 py-2.5 text-sm whitespace-pre-wrap ${
+                  msg.role === 'user' ? 'bg-[var(--accent)] text-white rounded-br-sm' : 'bg-[var(--bg-card)] border border-[var(--border)] text-[var(--text)] rounded-bl-sm'
+                }`}>
+                  {msg.content || (msg.isStreaming ? (
+                    <span className="inline-flex gap-1">
+                      <span className="w-1.5 h-1.5 rounded-full bg-[var(--text-tertiary)] animate-bounce" style={{ animationDelay: '0ms' }} />
+                      <span className="w-1.5 h-1.5 rounded-full bg-[var(--text-tertiary)] animate-bounce" style={{ animationDelay: '150ms' }} />
+                      <span className="w-1.5 h-1.5 rounded-full bg-[var(--text-tertiary)] animate-bounce" style={{ animationDelay: '300ms' }} />
+                    </span>
+                  ) : '')}
+                </div>
+              </div>
+            ))
+          )}
+          <div ref={messagesEndRef} />
+        </div>
 
-      {/* Input */}
-      <div className="border-t border-[var(--border)] bg-[var(--bg-card)] px-4 py-3">
-        <div className="flex gap-2 max-w-3xl mx-auto">
-          <textarea ref={inputRef} value={input} onChange={e => setInput(e.target.value)} onKeyDown={handleKeyDown}
-            placeholder={mode === 'agent' ? 'Message your agent...' : 'Message...'} rows={1}
-            className="flex-1 px-3 py-2 rounded-lg border border-[var(--border)] bg-[var(--bg)] text-[var(--text)] text-sm resize-none focus:outline-none focus:border-[var(--accent)]"
-            disabled={mode === 'connecting' || mode === 'disconnected'}
-            style={{ minHeight: '40px', maxHeight: '120px' }} />
-          <button onClick={handleSend} disabled={!input.trim() || sending || mode === 'connecting' || mode === 'disconnected'}
-            className="px-4 py-2 rounded-lg text-sm font-medium bg-[var(--accent)] text-white hover:opacity-90 transition-opacity disabled:opacity-30">
-            {sending ? '...' : 'Send'}
-          </button>
+        {/* Input */}
+        <div className="border-t border-[var(--border)] bg-[var(--bg-card)] px-4 py-3">
+          <div className="flex gap-2 max-w-3xl mx-auto">
+            <textarea ref={inputRef} value={input} onChange={e => setInput(e.target.value)} onKeyDown={handleKeyDown}
+              placeholder={mode === 'agent' ? 'Message your agent...' : 'Message...'} rows={1}
+              className="flex-1 px-3 py-2 rounded-lg border border-[var(--border)] bg-[var(--bg)] text-[var(--text)] text-sm resize-none focus:outline-none focus:border-[var(--accent)]"
+              disabled={mode === 'connecting' || mode === 'disconnected'}
+              style={{ minHeight: '40px', maxHeight: '120px' }} />
+            <button onClick={handleSend} disabled={!input.trim() || sending || mode === 'connecting' || mode === 'disconnected'}
+              className="px-4 py-2 rounded-lg text-sm font-medium bg-[var(--accent)] text-white hover:opacity-90 transition-opacity disabled:opacity-30">
+              {sending ? '...' : 'Send'}
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/dashboard/src/pages/instance/Chat.tsx
+++ b/dashboard/src/pages/instance/Chat.tsx
@@ -287,7 +287,15 @@ export default function Chat() {
               sessions.map(s => (
                 <button
                   key={s.sessionId}
-                  onClick={() => setActiveSession(s.sessionId)}
+                  onClick={() => {
+                    setActiveSession(s.sessionId)
+                    setMessages([{
+                      id: crypto.randomUUID(),
+                      role: 'system',
+                      content: `Resumed session: ${s.key.replace('agent:main:', '') || s.sessionId}\nModel: ${s.model} · ${formatTokens(s.totalTokens)} tokens\n\nPrevious messages are not loaded yet — new messages will continue this session.`,
+                      timestamp: Date.now(),
+                    }])
+                  }}
                   className={`w-full text-left px-3 py-2 text-sm transition-colors ${
                     activeSession === s.sessionId
                       ? 'bg-[var(--bg-hover)] text-[var(--text)]'

--- a/dashboard/src/pages/instance/OpenClawUI.tsx
+++ b/dashboard/src/pages/instance/OpenClawUI.tsx
@@ -1,0 +1,74 @@
+import { useState, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { fetchJSON } from '../../api/client'
+
+export default function OpenClawUI() {
+  const navigate = useNavigate()
+  const [uiUrl, setUiUrl] = useState<string | null>(null)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    fetchJSON<{ available: boolean; running: boolean }>('/api/v1/openclaw/status')
+      .then(s => {
+        if (s.running) {
+          // The gateway control UI is accessible via the container's IP
+          // We proxy it through Solon's gateway
+          setUiUrl('/api/v1/openclaw/ui')
+        } else {
+          setError('OpenClaw agent is not running. Start it from the Dashboard first.')
+        }
+      })
+      .catch(() => setError('Cannot reach Solon server'))
+  }, [])
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center h-[calc(100vh-3.5rem)]">
+        <div className="text-center max-w-sm">
+          <p className="text-4xl mb-4">🦞</p>
+          <p className="text-sm text-[var(--text-secondary)]">{error}</p>
+          <button onClick={() => navigate('/')}
+            className="mt-4 px-4 py-2 rounded-lg text-sm bg-[var(--accent)] text-white hover:opacity-90">
+            Go to Dashboard
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  if (!uiUrl) {
+    return (
+      <div className="flex items-center justify-center h-[calc(100vh-3.5rem)]">
+        <p className="text-sm text-[var(--text-tertiary)] animate-pulse">Connecting to OpenClaw...</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col h-[calc(100vh-3.5rem)]">
+      <div className="flex items-center justify-between px-4 py-2 border-b border-[var(--border)] bg-[var(--bg-card)]">
+        <div className="flex items-center gap-3">
+          <h1 className="text-sm font-semibold text-[var(--text)]">🦞 OpenClaw Control Panel</h1>
+          <span className="flex items-center gap-1.5 text-xs text-green-400">
+            <span className="w-1.5 h-1.5 rounded-full bg-green-400" />
+            Connected
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          <button onClick={() => window.open(uiUrl, '_blank')} className="text-xs text-[var(--accent)] hover:underline">
+            Open in new tab
+          </button>
+          <button onClick={() => navigate('/')} className="text-xs text-[var(--text-tertiary)] hover:text-[var(--text)]">
+            ← Dashboard
+          </button>
+        </div>
+      </div>
+      <iframe
+        src={uiUrl}
+        className="flex-1 w-full border-none"
+        title="OpenClaw Control Panel"
+        sandbox="allow-same-origin allow-scripts allow-popups allow-forms"
+      />
+    </div>
+  )
+}

--- a/docs/superpowers/plans/2026-04-11-finish-agent-track.md
+++ b/docs/superpowers/plans/2026-04-11-finish-agent-track.md
@@ -1,0 +1,1132 @@
+# Finish Agent Track Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete the remaining agent-track issues (#28, #29, #30, #31) — agent settings page, Telegram connect, conversation sidebar, and chat header controls.
+
+**Architecture:** All new features follow the existing pattern: thin Go HTTP handlers in `internal/gateway/` that call `ExecOpenClawCommand()` on the sandbox manager, with React pages in `dashboard/src/pages/instance/` consuming those endpoints via `fetchJSON()`. No new database tables needed — all config lives inside the OpenClaw container.
+
+**Tech Stack:** Go (chi router), React + TypeScript, Docker exec via OpenClaw CLI
+
+**Worktree:** `/Users/maximiliandaub/Code/solon-agents` (branch `product/solon-agents`)
+
+---
+
+## File Map
+
+### Backend (Go)
+- **Modify:** `internal/gateway/gateway.go` — add new route registrations
+- **Modify:** `internal/gateway/sandbox_handlers.go` — add handler functions for channels, agents, skills, workspace
+- **Modify:** `internal/sandbox/manager.go` — add `WriteToContainer()` helper
+
+### Frontend (React/TypeScript)
+- **Create:** `dashboard/src/pages/instance/AgentSettings.tsx` — agent settings page (model, channels, workspace, skills, access)
+- **Modify:** `dashboard/src/pages/instance/Chat.tsx` — add conversation sidebar + header controls
+- **Modify:** `dashboard/src/components/Sidebar.tsx` — add Agent Settings nav item
+- **Modify:** `dashboard/src/App.tsx` — add `/agent-settings` route
+
+---
+
+## Task 1: Backend API — OpenClaw proxy endpoints
+
+**Closes:** Foundation for #28, #29, #30, #31
+
+**Files:**
+- Modify: `internal/gateway/gateway.go:171-176` (route block)
+- Modify: `internal/gateway/sandbox_handlers.go` (append handlers)
+- Modify: `internal/sandbox/manager.go` (add WriteToContainer)
+
+- [ ] **Step 1: Add WriteToContainer to sandbox manager**
+
+Append to `internal/sandbox/manager.go` after `ExecOpenClawCommand`:
+
+```go
+// WriteToContainer writes content to a file inside the running OpenClaw container.
+func (m *Manager) WriteToContainer(ctx context.Context, filePath string, content string) error {
+	containers, err := m.docker.containerList(ctx, LabelManaged+"=true")
+	if err != nil {
+		return fmt.Errorf("listing containers: %w", err)
+	}
+
+	var containerID string
+	for _, c := range containers {
+		if c.Labels[LabelPolicy] == "openclaw-gateway" && c.State == "running" {
+			containerID = c.ID
+			break
+		}
+	}
+	if containerID == "" {
+		return fmt.Errorf("no running OpenClaw container found")
+	}
+
+	// Use sh -c with heredoc to write file content safely
+	cmd := []string{"sh", "-c", fmt.Sprintf("cat > %s << 'SOLON_EOF'\n%s\nSOLON_EOF", filePath, content)}
+	_, err = m.docker.containerExec(ctx, containerID, cmd, nil)
+	if err != nil {
+		return fmt.Errorf("writing to %s: %w", filePath, err)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 2: Add handler functions to sandbox_handlers.go**
+
+Append to `internal/gateway/sandbox_handlers.go`:
+
+```go
+func (g *Gateway) handleOpenClawChannels(w http.ResponseWriter, r *http.Request) {
+	if g.sandboxes == nil {
+		writeJSON(w, http.StatusOK, map[string]any{"channels": []any{}})
+		return
+	}
+
+	output, err := g.sandboxes.ExecOpenClawCommand(r.Context(), []string{"channels", "list", "--json"})
+	if err != nil {
+		writeJSON(w, http.StatusOK, map[string]any{"channels": []any{}})
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(output))
+}
+
+func (g *Gateway) handleOpenClawAddChannel(w http.ResponseWriter, r *http.Request) {
+	if g.sandboxes == nil {
+		writeError(w, http.StatusServiceUnavailable, "sandbox management not available")
+		return
+	}
+
+	var req struct {
+		Channel  string `json:"channel"`
+		BotToken string `json:"bot_token"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Channel == "" {
+		writeError(w, http.StatusBadRequest, "channel is required")
+		return
+	}
+
+	args := []string{"channels", "add", "--channel", req.Channel}
+	if req.BotToken != "" {
+		args = append(args, "--bot-token", req.BotToken)
+	}
+
+	output, err := g.sandboxes.ExecOpenClawCommand(r.Context(), args)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, fmt.Sprintf("failed to add channel: %v", err))
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"result": output})
+}
+
+func (g *Gateway) handleOpenClawRemoveChannel(w http.ResponseWriter, r *http.Request) {
+	if g.sandboxes == nil {
+		writeError(w, http.StatusServiceUnavailable, "sandbox management not available")
+		return
+	}
+
+	name := chi.URLParam(r, "name")
+	output, err := g.sandboxes.ExecOpenClawCommand(r.Context(), []string{"channels", "remove", "--channel", name})
+	if err != nil {
+		writeError(w, http.StatusBadGateway, fmt.Sprintf("failed to remove channel: %v", err))
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"result": output})
+}
+
+func (g *Gateway) handleOpenClawAgents(w http.ResponseWriter, r *http.Request) {
+	if g.sandboxes == nil {
+		writeJSON(w, http.StatusOK, map[string]any{"agents": []any{}})
+		return
+	}
+
+	output, err := g.sandboxes.ExecOpenClawCommand(r.Context(), []string{"agents", "list", "--json"})
+	if err != nil {
+		writeJSON(w, http.StatusOK, map[string]any{"agents": []any{}})
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(output))
+}
+
+func (g *Gateway) handleOpenClawSkills(w http.ResponseWriter, r *http.Request) {
+	if g.sandboxes == nil {
+		writeJSON(w, http.StatusOK, map[string]any{"skills": []any{}})
+		return
+	}
+
+	output, err := g.sandboxes.ExecOpenClawCommand(r.Context(), []string{"skills", "list", "--json"})
+	if err != nil {
+		writeJSON(w, http.StatusOK, map[string]any{"skills": []any{}})
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(output))
+}
+
+func (g *Gateway) handleOpenClawReadFile(w http.ResponseWriter, r *http.Request) {
+	if g.sandboxes == nil {
+		writeError(w, http.StatusServiceUnavailable, "sandbox management not available")
+		return
+	}
+
+	filename := chi.URLParam(r, "filename")
+	allowed := map[string]bool{"SOUL.md": true, "IDENTITY.md": true, "USER.md": true, "AGENTS.md": true}
+	if !allowed[filename] {
+		writeError(w, http.StatusBadRequest, "file not allowed")
+		return
+	}
+
+	output, err := g.sandboxes.ExecOpenClawCommand(r.Context(), []string{"sh", "-c", "cat /root/.openclaw/workspace/" + filename + " 2>/dev/null || echo ''"})
+	if err != nil {
+		// File doesn't exist yet — return empty
+		writeJSON(w, http.StatusOK, map[string]string{"filename": filename, "content": ""})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"filename": filename, "content": output})
+}
+
+func (g *Gateway) handleOpenClawWriteFile(w http.ResponseWriter, r *http.Request) {
+	if g.sandboxes == nil {
+		writeError(w, http.StatusServiceUnavailable, "sandbox management not available")
+		return
+	}
+
+	filename := chi.URLParam(r, "filename")
+	allowed := map[string]bool{"SOUL.md": true, "IDENTITY.md": true, "USER.md": true, "AGENTS.md": true}
+	if !allowed[filename] {
+		writeError(w, http.StatusBadRequest, "file not allowed")
+		return
+	}
+
+	var req struct {
+		Content string `json:"content"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	filePath := "/root/.openclaw/workspace/" + filename
+	if err := g.sandboxes.WriteToContainer(r.Context(), filePath, req.Content); err != nil {
+		writeError(w, http.StatusBadGateway, fmt.Sprintf("failed to write file: %v", err))
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "saved"})
+}
+```
+
+Note: `handleOpenClawReadFile` shells out with `sh -c cat ...` rather than using `ExecOpenClawCommand` which prepends "openclaw". We need to use `ExecOpenClawCommand` with the raw file-reading approach. Actually, we need a different helper. Let's instead use docker exec directly through the existing sandbox manager pattern. Change `handleOpenClawReadFile` to use a raw exec:
+
+```go
+func (g *Gateway) handleOpenClawReadFile(w http.ResponseWriter, r *http.Request) {
+	if g.sandboxes == nil {
+		writeError(w, http.StatusServiceUnavailable, "sandbox management not available")
+		return
+	}
+
+	filename := chi.URLParam(r, "filename")
+	allowed := map[string]bool{"SOUL.md": true, "IDENTITY.md": true, "USER.md": true, "AGENTS.md": true}
+	if !allowed[filename] {
+		writeError(w, http.StatusBadRequest, "file not allowed")
+		return
+	}
+
+	filePath := "/root/.openclaw/workspace/" + filename
+	output, err := g.sandboxes.ExecInContainer(r.Context(), []string{"cat", filePath})
+	if err != nil {
+		writeJSON(w, http.StatusOK, map[string]string{"filename": filename, "content": ""})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"filename": filename, "content": output})
+}
+```
+
+And add `ExecInContainer` to `internal/sandbox/manager.go`:
+
+```go
+// ExecInContainer runs a raw command inside the OpenClaw container (no "openclaw" prefix).
+func (m *Manager) ExecInContainer(ctx context.Context, cmd []string) (string, error) {
+	containers, err := m.docker.containerList(ctx, LabelManaged+"=true")
+	if err != nil {
+		return "", fmt.Errorf("listing containers: %w", err)
+	}
+
+	var containerID string
+	for _, c := range containers {
+		if c.Labels[LabelPolicy] == "openclaw-gateway" && c.State == "running" {
+			containerID = c.ID
+			break
+		}
+	}
+	if containerID == "" {
+		return "", fmt.Errorf("no running OpenClaw container found")
+	}
+
+	output, err := m.docker.containerExec(ctx, containerID, cmd, nil)
+	if err != nil {
+		return "", fmt.Errorf("exec %v: %w", cmd, err)
+	}
+	return output, nil
+}
+```
+
+- [ ] **Step 3: Register routes in gateway.go**
+
+Add these lines after line 176 (`r.Get("/api/v1/openclaw/ui", g.handleOpenClawUI)`):
+
+```go
+		r.Get("/api/v1/openclaw/channels", g.handleOpenClawChannels)
+		r.Post("/api/v1/openclaw/channels", g.handleOpenClawAddChannel)
+		r.Delete("/api/v1/openclaw/channels/{name}", g.handleOpenClawRemoveChannel)
+		r.Get("/api/v1/openclaw/agents", g.handleOpenClawAgents)
+		r.Get("/api/v1/openclaw/skills", g.handleOpenClawSkills)
+		r.Get("/api/v1/openclaw/workspace/{filename}", g.handleOpenClawReadFile)
+		r.Put("/api/v1/openclaw/workspace/{filename}", g.handleOpenClawWriteFile)
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `cd /Users/maximiliandaub/Code/solon-agents && go build ./...`
+Expected: No errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/gateway/gateway.go internal/gateway/sandbox_handlers.go internal/sandbox/manager.go
+git commit -m "feat: add openclaw API endpoints for channels, agents, skills, workspace"
+```
+
+---
+
+## Task 2: Agent Settings page — model + access sections
+
+**Closes:** #28 (partial — model + access sections)
+
+**Files:**
+- Create: `dashboard/src/pages/instance/AgentSettings.tsx`
+- Modify: `dashboard/src/App.tsx` — add route
+- Modify: `dashboard/src/components/Sidebar.tsx` — add nav item
+
+- [ ] **Step 1: Create AgentSettings.tsx with model + access sections**
+
+Create `dashboard/src/pages/instance/AgentSettings.tsx`:
+
+```tsx
+import { useState, useEffect } from 'react'
+import { fetchJSON, getLocalApiKey, isNonLocalhost } from '../../api/client'
+import Card from '../../components/Card'
+
+function authHeaders(): Record<string, string> {
+  const apiKey = isNonLocalhost() ? getLocalApiKey() : null
+  return apiKey ? { Authorization: `Bearer ${apiKey}` } : {}
+}
+
+interface AgentInfo {
+  name: string
+  model?: string
+  modelProvider?: string
+}
+
+interface ChannelInfo {
+  name: string
+  type: string
+  status: string
+  username?: string
+}
+
+interface SkillInfo {
+  name: string
+  description?: string
+  enabled: boolean
+}
+
+type SettingsTab = 'model' | 'channels' | 'workspace' | 'skills' | 'access'
+
+export default function AgentSettings() {
+  const [tab, setTab] = useState<SettingsTab>('model')
+  const [agents, setAgents] = useState<AgentInfo[]>([])
+  const [channels, setChannels] = useState<ChannelInfo[]>([])
+  const [skills, setSkills] = useState<SkillInfo[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    setLoading(true)
+    Promise.all([
+      fetchJSON<{ agents?: AgentInfo[] }>('/api/v1/openclaw/agents')
+        .then(d => setAgents(d.agents || []))
+        .catch(() => {}),
+      fetchJSON<{ channels?: ChannelInfo[] }>('/api/v1/openclaw/channels')
+        .then(d => setChannels(d.channels || []))
+        .catch(() => {}),
+      fetchJSON<{ skills?: SkillInfo[] }>('/api/v1/openclaw/skills')
+        .then(d => setSkills(d.skills || []))
+        .catch(() => {}),
+    ]).finally(() => setLoading(false))
+  }, [])
+
+  const tabs: { key: SettingsTab; label: string }[] = [
+    { key: 'model', label: 'Model' },
+    { key: 'channels', label: 'Channels' },
+    { key: 'workspace', label: 'Workspace' },
+    { key: 'skills', label: 'Skills' },
+    { key: 'access', label: 'Access' },
+  ]
+
+  return (
+    <main className="max-w-4xl mx-auto px-4 sm:px-6 py-8 space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight text-[var(--text)]">Agent Settings</h1>
+        <p className="text-sm text-[var(--text-tertiary)] mt-1">Configure your OpenClaw agent</p>
+      </div>
+
+      {error && (
+        <div className="px-4 py-2 rounded-lg bg-red-500/10 text-red-400 text-xs flex items-center justify-between">
+          <span>{error}</span>
+          <button onClick={() => setError('')} className="underline">dismiss</button>
+        </div>
+      )}
+
+      {/* Tab bar */}
+      <div className="flex gap-1 border-b border-[var(--border)]">
+        {tabs.map(t => (
+          <button
+            key={t.key}
+            onClick={() => setTab(t.key)}
+            className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+              tab === t.key
+                ? 'border-[var(--accent)] text-[var(--text)]'
+                : 'border-transparent text-[var(--text-tertiary)] hover:text-[var(--text-secondary)]'
+            }`}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      {loading ? (
+        <p className="text-sm text-[var(--text-tertiary)] animate-pulse">Loading agent configuration...</p>
+      ) : (
+        <>
+          {tab === 'model' && <ModelSection agents={agents} onError={setError} />}
+          {tab === 'channels' && <ChannelsSection channels={channels} setChannels={setChannels} onError={setError} />}
+          {tab === 'workspace' && <WorkspaceSection onError={setError} />}
+          {tab === 'skills' && <SkillsSection skills={skills} />}
+          {tab === 'access' && <AccessSection />}
+        </>
+      )}
+    </main>
+  )
+}
+
+/* ── Model Section ─────────────────────────────────────────────── */
+
+function ModelSection({ agents, onError }: { agents: AgentInfo[]; onError: (e: string) => void }) {
+  const agent = agents[0]
+
+  return (
+    <Card className="p-5 space-y-4">
+      <h3 className="text-sm font-semibold text-[var(--text)]">Model Configuration</h3>
+      <div className="space-y-3">
+        <div>
+          <label className="block text-xs text-[var(--text-tertiary)] mb-1">Current Model</label>
+          <p className="text-sm text-[var(--text)]">{agent?.model || 'claude-sonnet-4-6'}</p>
+        </div>
+        <div>
+          <label className="block text-xs text-[var(--text-tertiary)] mb-1">Provider</label>
+          <p className="text-sm text-[var(--text)]">{agent?.modelProvider || 'anthropic'}</p>
+        </div>
+      </div>
+      <p className="text-xs text-[var(--text-tertiary)]">
+        Model configuration is managed via the OpenClaw workspace files. Edit AGENTS.md in the Workspace tab to change the model.
+      </p>
+    </Card>
+  )
+}
+
+/* ── Channels Section ──────────────────────────────────────────── */
+
+function ChannelsSection({ channels, setChannels, onError }: {
+  channels: ChannelInfo[]
+  setChannels: (c: ChannelInfo[]) => void
+  onError: (e: string) => void
+}) {
+  const [showTelegram, setShowTelegram] = useState(false)
+  const [botToken, setBotToken] = useState('')
+  const [connecting, setConnecting] = useState(false)
+  const [removing, setRemoving] = useState<string | null>(null)
+
+  async function handleConnectTelegram() {
+    const token = botToken.trim()
+    if (!token) return
+    setConnecting(true)
+    onError('')
+    try {
+      await fetch('/api/v1/openclaw/channels', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeaders() },
+        body: JSON.stringify({ channel: 'telegram', bot_token: token }),
+      }).then(async r => {
+        if (!r.ok) {
+          const err = await r.json().catch(() => ({ error: r.statusText })) as { error?: string }
+          throw new Error(err.error || `HTTP ${r.status}`)
+        }
+      })
+      setBotToken('')
+      setShowTelegram(false)
+      // Reload channels
+      const d = await fetchJSON<{ channels?: ChannelInfo[] }>('/api/v1/openclaw/channels')
+      setChannels(d.channels || [])
+    } catch (e) {
+      onError((e as Error).message)
+    } finally {
+      setConnecting(false)
+    }
+  }
+
+  async function handleRemove(name: string) {
+    setRemoving(name)
+    try {
+      await fetch(`/api/v1/openclaw/channels/${encodeURIComponent(name)}`, {
+        method: 'DELETE',
+        headers: authHeaders(),
+      })
+      setChannels(channels.filter(c => c.name !== name))
+    } catch (e) {
+      onError((e as Error).message)
+    } finally {
+      setRemoving(null)
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <Card className="p-5 space-y-4">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-semibold text-[var(--text)]">Connected Channels</h3>
+        </div>
+
+        {channels.length === 0 ? (
+          <p className="text-sm text-[var(--text-tertiary)]">No channels connected yet.</p>
+        ) : (
+          <div className="space-y-2">
+            {channels.map(ch => (
+              <div key={ch.name} className="flex items-center justify-between px-3 py-2 rounded-lg bg-[var(--bg)]">
+                <div className="flex items-center gap-3">
+                  <span className="text-lg">{ch.type === 'telegram' ? '📱' : ch.type === 'whatsapp' ? '💬' : ch.type === 'discord' ? '🎮' : '🔌'}</span>
+                  <div>
+                    <p className="text-sm text-[var(--text)]">{ch.name}</p>
+                    <p className="text-xs text-[var(--text-tertiary)]">{ch.type}{ch.username ? ` · @${ch.username}` : ''}</p>
+                  </div>
+                </div>
+                <div className="flex items-center gap-3">
+                  <span className={`flex items-center gap-1.5 text-xs ${ch.status === 'connected' ? 'text-green-400' : 'text-yellow-400'}`}>
+                    <span className={`w-1.5 h-1.5 rounded-full ${ch.status === 'connected' ? 'bg-green-400' : 'bg-yellow-400'}`} />
+                    {ch.status}
+                  </span>
+                  <button onClick={() => handleRemove(ch.name)} disabled={removing === ch.name}
+                    className="text-xs text-red-400 hover:text-red-300 disabled:opacity-50">
+                    {removing === ch.name ? '...' : 'Disconnect'}
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </Card>
+
+      {/* Connect Telegram */}
+      <Card className="p-5 space-y-4">
+        <h3 className="text-sm font-semibold text-[var(--text)]">Connect a Channel</h3>
+
+        {!showTelegram ? (
+          <div className="flex gap-3">
+            <button onClick={() => setShowTelegram(true)}
+              className="flex items-center gap-2 px-4 py-2 rounded-lg border border-[var(--border)] hover:border-blue-500/30 text-sm text-[var(--text)] transition-colors">
+              📱 Telegram
+            </button>
+            <button disabled
+              className="flex items-center gap-2 px-4 py-2 rounded-lg border border-[var(--border)] text-sm text-[var(--text-tertiary)] opacity-50 cursor-not-allowed">
+              💬 WhatsApp (soon)
+            </button>
+            <button disabled
+              className="flex items-center gap-2 px-4 py-2 rounded-lg border border-[var(--border)] text-sm text-[var(--text-tertiary)] opacity-50 cursor-not-allowed">
+              🎮 Discord (soon)
+            </button>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            <p className="text-xs text-[var(--text-secondary)]">
+              1. Message <code className="text-[var(--accent)]">@BotFather</code> on Telegram<br />
+              2. Send <code className="text-[var(--accent)]">/newbot</code> and follow the instructions<br />
+              3. Paste the bot token below
+            </p>
+            <div className="flex gap-2">
+              <input
+                value={botToken}
+                onChange={e => setBotToken(e.target.value)}
+                onKeyDown={e => e.key === 'Enter' && handleConnectTelegram()}
+                placeholder="123456789:ABCdefGHI..."
+                className="flex-1 px-3 py-2 rounded-lg border border-[var(--border)] bg-[var(--bg)] text-[var(--text)] text-sm font-mono focus:outline-none focus:border-[var(--accent)]"
+                disabled={connecting}
+              />
+              <button onClick={handleConnectTelegram} disabled={!botToken.trim() || connecting}
+                className="px-4 py-2 rounded-lg text-sm font-medium bg-[var(--accent)] text-white hover:opacity-90 disabled:opacity-30">
+                {connecting ? 'Connecting...' : 'Connect'}
+              </button>
+              <button onClick={() => { setShowTelegram(false); setBotToken('') }}
+                className="px-3 py-2 rounded-lg text-sm text-[var(--text-tertiary)] hover:text-[var(--text)]">
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+      </Card>
+    </div>
+  )
+}
+
+/* ── Workspace Section ─────────────────────────────────────────── */
+
+function WorkspaceSection({ onError }: { onError: (e: string) => void }) {
+  const files = ['SOUL.md', 'IDENTITY.md', 'USER.md', 'AGENTS.md'] as const
+  const [selectedFile, setSelectedFile] = useState<string>(files[0])
+  const [content, setContent] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [saved, setSaved] = useState(false)
+
+  useEffect(() => {
+    setLoading(true)
+    setSaved(false)
+    fetchJSON<{ content: string }>(`/api/v1/openclaw/workspace/${selectedFile}`)
+      .then(d => setContent(d.content || ''))
+      .catch(() => setContent(''))
+      .finally(() => setLoading(false))
+  }, [selectedFile])
+
+  async function handleSave() {
+    setSaving(true)
+    onError('')
+    try {
+      await fetch(`/api/v1/openclaw/workspace/${selectedFile}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', ...authHeaders() },
+        body: JSON.stringify({ content }),
+      }).then(async r => {
+        if (!r.ok) {
+          const err = await r.json().catch(() => ({ error: r.statusText })) as { error?: string }
+          throw new Error(err.error || `HTTP ${r.status}`)
+        }
+      })
+      setSaved(true)
+      setTimeout(() => setSaved(false), 2000)
+    } catch (e) {
+      onError((e as Error).message)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Card className="p-5 space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-[var(--text)]">Workspace Files</h3>
+        <div className="flex items-center gap-2">
+          {saved && <span className="text-xs text-green-400">Saved</span>}
+          <button onClick={handleSave} disabled={saving || loading}
+            className="px-3 py-1.5 rounded-lg text-xs font-medium bg-[var(--accent)] text-white hover:opacity-90 disabled:opacity-30">
+            {saving ? 'Saving...' : 'Save'}
+          </button>
+        </div>
+      </div>
+
+      <div className="flex gap-2">
+        {files.map(f => (
+          <button
+            key={f}
+            onClick={() => setSelectedFile(f)}
+            className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${
+              selectedFile === f
+                ? 'bg-[var(--accent)] text-white'
+                : 'bg-[var(--bg)] text-[var(--text-secondary)] hover:text-[var(--text)]'
+            }`}
+          >
+            {f}
+          </button>
+        ))}
+      </div>
+
+      <p className="text-xs text-[var(--text-tertiary)]">
+        {selectedFile === 'SOUL.md' && 'Core personality and behavior rules for your agent.'}
+        {selectedFile === 'IDENTITY.md' && 'Who the agent is — name, role, background.'}
+        {selectedFile === 'USER.md' && 'Information about you that helps the agent personalize responses.'}
+        {selectedFile === 'AGENTS.md' && 'Multi-agent configuration — define sub-agents and their roles.'}
+      </p>
+
+      {loading ? (
+        <div className="h-64 flex items-center justify-center">
+          <p className="text-sm text-[var(--text-tertiary)] animate-pulse">Loading...</p>
+        </div>
+      ) : (
+        <textarea
+          value={content}
+          onChange={e => { setContent(e.target.value); setSaved(false) }}
+          className="w-full h-64 px-3 py-2 rounded-lg border border-[var(--border)] bg-[var(--bg)] text-[var(--text)] text-sm font-mono resize-y focus:outline-none focus:border-[var(--accent)]"
+          placeholder={`# ${selectedFile}\n\nWrite your agent instructions here...`}
+        />
+      )}
+    </Card>
+  )
+}
+
+/* ── Skills Section ────────────────────────────────────────────── */
+
+function SkillsSection({ skills }: { skills: SkillInfo[] }) {
+  return (
+    <Card className="p-5 space-y-4">
+      <h3 className="text-sm font-semibold text-[var(--text)]">Skills</h3>
+      {skills.length === 0 ? (
+        <p className="text-sm text-[var(--text-tertiary)]">No skills found. Skills are managed in the OpenClaw workspace.</p>
+      ) : (
+        <div className="space-y-2">
+          {skills.map(s => (
+            <div key={s.name} className="flex items-center justify-between px-3 py-2 rounded-lg bg-[var(--bg)]">
+              <div>
+                <p className="text-sm text-[var(--text)]">{s.name}</p>
+                {s.description && <p className="text-xs text-[var(--text-tertiary)]">{s.description}</p>}
+              </div>
+              <span className={`text-xs ${s.enabled ? 'text-green-400' : 'text-[var(--text-tertiary)]'}`}>
+                {s.enabled ? 'Active' : 'Inactive'}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </Card>
+  )
+}
+
+/* ── Access Section ────────────────────────────────────────────── */
+
+function CopyField({ label, value }: { label: string; value: string }) {
+  const [copied, setCopied] = useState(false)
+  function handleCopy() {
+    navigator.clipboard.writeText(value).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    })
+  }
+  return (
+    <div className="flex items-center justify-between px-3 py-2 rounded-lg bg-[var(--bg)]">
+      <div>
+        <p className="text-xs text-[var(--text-tertiary)]">{label}</p>
+        <code className="text-xs text-[var(--text)] font-mono">{value}</code>
+      </div>
+      <button onClick={handleCopy} className="text-xs text-[var(--accent)] hover:underline">
+        {copied ? 'Copied' : 'Copy'}
+      </button>
+    </div>
+  )
+}
+
+function AccessSection() {
+  const host = window.location.hostname
+  return (
+    <Card className="p-5 space-y-3">
+      <h3 className="text-sm font-semibold text-[var(--text)]">Access Methods</h3>
+      <CopyField label="SSH" value={`ssh root@${host}`} />
+      <CopyField label="TUI" value="docker exec -it openclaw-sandbox-openclaw openclaw tui" />
+      <CopyField label="API" value={`POST ${window.location.origin}/api/v1/openclaw/send`} />
+      <div className="flex items-center justify-between px-3 py-2 rounded-lg bg-[var(--bg)]">
+        <div>
+          <p className="text-xs text-[var(--text-tertiary)]">OpenClaw UI</p>
+          <p className="text-xs text-[var(--text)]">Full control panel</p>
+        </div>
+        <button onClick={() => window.open('/api/v1/openclaw/ui', '_blank')}
+          className="text-xs text-[var(--accent)] hover:underline">Open</button>
+      </div>
+    </Card>
+  )
+}
+```
+
+- [ ] **Step 2: Add route to App.tsx**
+
+Add import after the OpenClawUI import:
+```tsx
+import AgentSettings from './pages/instance/AgentSettings'
+```
+
+Add route after the `/openclaw` route:
+```tsx
+<Route path="/agent-settings" element={<LocalRoute><AgentSettings /></LocalRoute>} />
+```
+
+- [ ] **Step 3: Add nav item in Sidebar.tsx**
+
+Add to the `agentsSection` items array after the OpenClaw UI entry:
+```tsx
+    {
+      to: '/agent-settings',
+      label: 'Agent Settings',
+      icon: <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="3" /><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" /></svg>,
+    },
+```
+
+- [ ] **Step 4: Build dashboard and verify**
+
+Run: `cd /Users/maximiliandaub/Code/solon-agents && make build-dashboard`
+Expected: No errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/src/pages/instance/AgentSettings.tsx dashboard/src/App.tsx dashboard/src/components/Sidebar.tsx
+git commit -m "feat: agent settings page — model, channels, workspace, skills, access (#28)"
+```
+
+---
+
+## Task 3: Conversation sidebar in Chat
+
+**Closes:** #30
+
+**Files:**
+- Modify: `dashboard/src/pages/instance/Chat.tsx`
+
+- [ ] **Step 1: Add session types and sidebar state to Chat.tsx**
+
+Add below the existing `ChatMessage` interface:
+
+```tsx
+interface SessionInfo {
+  key: string
+  sessionId: string
+  model: string
+  modelProvider: string
+  totalTokens: number
+  updatedAt: number
+}
+```
+
+Add to the state declarations in the `Chat` component:
+
+```tsx
+const [sessions, setSessions] = useState<SessionInfo[]>([])
+const [sidebarOpen, setSidebarOpen] = useState(true)
+const [activeSession, setActiveSession] = useState<string | null>(null)
+```
+
+- [ ] **Step 2: Load sessions on mount**
+
+Add a `loadSessions` function and call it in the existing `useEffect`:
+
+```tsx
+const loadSessions = useCallback(async () => {
+  try {
+    const d = await fetchJSON<{ sessions?: SessionInfo[] }>('/api/v1/openclaw/sessions')
+    setSessions(d.sessions || [])
+  } catch { /* */ }
+}, [])
+```
+
+Call `loadSessions()` inside the existing `useEffect(() => { connect() }, [])` — change it to:
+```tsx
+useEffect(() => {
+  connect()
+  loadSessions()
+}, [])
+```
+
+- [ ] **Step 3: Add session helpers**
+
+```tsx
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`
+  return String(n)
+}
+
+function timeAgo(timestamp: number): string {
+  const diff = Date.now() - timestamp
+  const mins = Math.floor(diff / 60000)
+  if (mins < 60) return `${mins}m ago`
+  const hours = Math.floor(mins / 60)
+  if (hours < 24) return `${hours}h ago`
+  return `${Math.floor(hours / 24)}d ago`
+}
+```
+
+- [ ] **Step 4: Restructure the return JSX to include sidebar**
+
+Replace the outer `<div>` with a flex layout:
+
+```tsx
+return (
+  <div className="flex h-[calc(100vh-3.5rem)]">
+    {/* Sidebar */}
+    {sidebarOpen && mode === 'agent' && (
+      <div className="w-64 border-r border-[var(--border)] bg-[var(--bg-card)] flex flex-col shrink-0">
+        <div className="flex items-center justify-between px-3 py-2 border-b border-[var(--border)]">
+          <span className="text-xs font-medium text-[var(--text-tertiary)] uppercase tracking-wider">Conversations</span>
+          <button onClick={() => { setActiveSession(null); setMessages([]) }}
+            className="text-xs text-[var(--accent)] hover:underline">New</button>
+        </div>
+        <div className="flex-1 overflow-y-auto">
+          {sessions.length === 0 ? (
+            <p className="px-3 py-4 text-xs text-[var(--text-tertiary)]">No conversations yet</p>
+          ) : (
+            sessions.map(s => (
+              <button
+                key={s.sessionId}
+                onClick={() => setActiveSession(s.sessionId)}
+                className={`w-full text-left px-3 py-2 text-sm transition-colors ${
+                  activeSession === s.sessionId
+                    ? 'bg-[var(--bg-hover)] text-[var(--text)]'
+                    : 'text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]'
+                }`}
+              >
+                <p className="truncate text-xs">{s.key.replace('agent:main:', '') || 'Conversation'}</p>
+                <p className="text-[10px] text-[var(--text-tertiary)] mt-0.5">
+                  {s.model} · {formatTokens(s.totalTokens)} tokens · {timeAgo(s.updatedAt)}
+                </p>
+              </button>
+            ))
+          )}
+        </div>
+      </div>
+    )}
+
+    {/* Main chat area */}
+    <div className="flex-1 flex flex-col min-w-0">
+      {/* ... existing header, messages, input ... */}
+    </div>
+  </div>
+)
+```
+
+- [ ] **Step 5: Add sidebar toggle button to header**
+
+Add a toggle button at the start of the header's left side:
+
+```tsx
+{mode === 'agent' && (
+  <button onClick={() => setSidebarOpen(!sidebarOpen)}
+    className="p-1 rounded text-[var(--text-tertiary)] hover:text-[var(--text)] hover:bg-[var(--bg-hover)]">
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="3" y="3" width="18" height="18" rx="2" /><line x1="9" y1="3" x2="9" y2="21" />
+    </svg>
+  </button>
+)}
+```
+
+- [ ] **Step 6: Build and verify**
+
+Run: `cd /Users/maximiliandaub/Code/solon-agents && make build-dashboard`
+Expected: No errors
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add dashboard/src/pages/instance/Chat.tsx
+git commit -m "feat: conversation sidebar using OpenClaw sessions (#30)"
+```
+
+---
+
+## Task 4: Agent selector + model switcher in Chat header
+
+**Closes:** #31
+
+**Files:**
+- Modify: `dashboard/src/pages/instance/Chat.tsx`
+
+- [ ] **Step 1: Add agent state to Chat component**
+
+Add new state:
+
+```tsx
+const [agentList, setAgentList] = useState<{ name: string }[]>([])
+const [selectedAgent, setSelectedAgent] = useState('main')
+const [thinkingLevel, setThinkingLevel] = useState<'off' | 'low' | 'medium' | 'high'>('medium')
+```
+
+Load agents on mount (add to the existing useEffect):
+
+```tsx
+fetchJSON<{ agents?: { name: string }[] }>('/api/v1/openclaw/agents')
+  .then(d => setAgentList(d.agents || []))
+  .catch(() => {})
+```
+
+- [ ] **Step 2: Update the agent send to pass agent + thinking level**
+
+Modify the `sendViaAgent` function's fetch body to include agent selection:
+
+```tsx
+body: JSON.stringify({ message: text, agent: selectedAgent, thinking: thinkingLevel }),
+```
+
+And update the backend handler `handleOpenClawSend` to accept these:
+
+In `internal/gateway/sandbox_handlers.go`, update the request struct:
+
+```go
+var req struct {
+    Message  string `json:"message"`
+    Agent    string `json:"agent"`
+    Thinking string `json:"thinking"`
+}
+```
+
+And update the exec command:
+
+```go
+agent := req.Agent
+if agent == "" {
+    agent = "main"
+}
+args := []string{"agent", "--agent", agent, "--message", req.Message, "--json", "--timeout", "180"}
+if req.Thinking != "" && req.Thinking != "off" {
+    args = append(args, "--thinking", req.Thinking)
+}
+output, err := g.sandboxes.ExecOpenClawCommand(r.Context(), args)
+```
+
+Note: This replaces `ExecOpenClawAgent` with `ExecOpenClawCommand` since we need custom args.
+
+- [ ] **Step 3: Update Chat header with agent selector + thinking toggle**
+
+Replace the existing header left section with:
+
+```tsx
+<div className="flex items-center gap-3">
+  {mode === 'agent' && (
+    <button onClick={() => setSidebarOpen(!sidebarOpen)}
+      className="p-1 rounded text-[var(--text-tertiary)] hover:text-[var(--text)] hover:bg-[var(--bg-hover)]">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <rect x="3" y="3" width="18" height="18" rx="2" /><line x1="9" y1="3" x2="9" y2="21" />
+      </svg>
+    </button>
+  )}
+  <h1 className="text-sm font-semibold text-[var(--text)]">Chat</h1>
+  <span className={`flex items-center gap-1.5 text-xs ${modeColor}`}>
+    <span className={`w-1.5 h-1.5 rounded-full ${dotColor}`} />
+    {modeLabel}
+  </span>
+
+  {/* Agent selector — only in agent mode with multiple agents */}
+  {mode === 'agent' && agentList.length > 1 && (
+    <select value={selectedAgent} onChange={e => setSelectedAgent(e.target.value)}
+      className="text-xs px-2 py-1 rounded border border-[var(--border)] bg-[var(--bg)] text-[var(--text)]">
+      {agentList.map(a => <option key={a.name} value={a.name}>{a.name}</option>)}
+    </select>
+  )}
+
+  {/* Thinking level — only in agent mode */}
+  {mode === 'agent' && (
+    <select value={thinkingLevel} onChange={e => setThinkingLevel(e.target.value as typeof thinkingLevel)}
+      className="text-xs px-2 py-1 rounded border border-[var(--border)] bg-[var(--bg)] text-[var(--text)]">
+      <option value="off">Thinking: Off</option>
+      <option value="low">Thinking: Low</option>
+      <option value="medium">Thinking: Medium</option>
+      <option value="high">Thinking: High</option>
+    </select>
+  )}
+
+  {/* Model selector — only in direct mode */}
+  {mode === 'direct' && models.length > 0 && (
+    <select value={selectedModel} onChange={e => setSelectedModel(e.target.value)}
+      className="text-xs px-2 py-1 rounded border border-[var(--border)] bg-[var(--bg)] text-[var(--text)]">
+      {models.map(m => <option key={m.name} value={m.name}>{m.name}</option>)}
+    </select>
+  )}
+</div>
+```
+
+- [ ] **Step 4: Build both Go backend and dashboard**
+
+Run: `cd /Users/maximiliandaub/Code/solon-agents && go build ./... && make build-dashboard`
+Expected: No errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/src/pages/instance/Chat.tsx internal/gateway/sandbox_handlers.go
+git commit -m "feat: agent selector + model switcher + thinking toggle in Chat header (#31)"
+```
+
+---
+
+## Task 5: Update Home page to link to Agent Settings
+
+**Files:**
+- Modify: `dashboard/src/pages/Home.tsx`
+
+- [ ] **Step 1: Replace settings link in action cards**
+
+In Home.tsx, update the third action card (currently "Channels" linking to `/settings`) to link to `/agent-settings`:
+
+```tsx
+<button onClick={() => navigate('/agent-settings')}
+  className="text-left p-5 rounded-xl border border-[var(--border)] bg-[var(--bg-card)] hover:border-blue-500/30 transition-colors">
+  <div className="text-2xl mb-2">⚙️</div>
+  <h3 className="text-sm font-semibold text-[var(--text)]">Agent Settings</h3>
+  <p className="text-xs text-[var(--text-tertiary)] mt-1">Model, channels, workspace, skills</p>
+</button>
+```
+
+- [ ] **Step 2: Build and verify**
+
+Run: `cd /Users/maximiliandaub/Code/solon-agents && make build-dashboard`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add dashboard/src/pages/Home.tsx
+git commit -m "feat: link agent cockpit to agent settings page"
+```
+
+---
+
+## Task 6: Final build + cleanup PR
+
+- [ ] **Step 1: Full build**
+
+Run: `cd /Users/maximiliandaub/Code/solon-agents && go build ./... && make build-dashboard`
+Expected: No errors
+
+- [ ] **Step 2: Create PR**
+
+```bash
+gh pr create --base master --head product/solon-agents \
+  --title "feat: finish agent track — settings, channels, chat sidebar" \
+  --body "## Summary
+- Agent settings page with model, channels, workspace editor, skills, and access sections (#28)
+- Telegram channel connect from dashboard (#29)
+- Conversation sidebar using OpenClaw sessions (#30)
+- Agent selector + model switcher + thinking toggle in Chat header (#31)
+
+Closes #28, #29, #30, #31
+
+## Test plan
+- [ ] Navigate to Agent Settings page from sidebar
+- [ ] Verify model section shows current model
+- [ ] Connect a Telegram bot via Channels tab
+- [ ] Edit and save a workspace file (SOUL.md)
+- [ ] Open Chat — verify conversation sidebar loads sessions
+- [ ] Send a message and verify thinking level toggle works
+- [ ] Verify agent selector appears when multiple agents exist"
+```

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -174,6 +174,13 @@ func (g *Gateway) setupRoutes() {
 		r.Post("/api/v1/openclaw/send", g.handleOpenClawSend)
 		r.Get("/api/v1/openclaw/sessions", g.handleOpenClawSessions)
 		r.Get("/api/v1/openclaw/ui", g.handleOpenClawUI)
+		r.Get("/api/v1/openclaw/channels", g.handleOpenClawChannels)
+		r.Post("/api/v1/openclaw/channels", g.handleOpenClawAddChannel)
+		r.Delete("/api/v1/openclaw/channels/{name}", g.handleOpenClawRemoveChannel)
+		r.Get("/api/v1/openclaw/agents", g.handleOpenClawAgents)
+		r.Get("/api/v1/openclaw/skills", g.handleOpenClawSkills)
+		r.Get("/api/v1/openclaw/workspace/{filename}", g.handleOpenClawReadFile)
+		r.Put("/api/v1/openclaw/workspace/{filename}", g.handleOpenClawWriteFile)
 	})
 
 	// OpenClaw WebSocket proxy (separate group for query param auth support)

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -172,6 +172,8 @@ func (g *Gateway) setupRoutes() {
 		r.Post("/api/v1/openclaw/start", g.handleOpenClawStart)
 		r.Get("/api/v1/openclaw/status", g.handleOpenClawStatus)
 		r.Post("/api/v1/openclaw/send", g.handleOpenClawSend)
+		r.Get("/api/v1/openclaw/sessions", g.handleOpenClawSessions)
+		r.Get("/api/v1/openclaw/ui", g.handleOpenClawUI)
 	})
 
 	// OpenClaw WebSocket proxy (separate group for query param auth support)

--- a/internal/gateway/sandbox_handlers.go
+++ b/internal/gateway/sandbox_handlers.go
@@ -339,6 +339,41 @@ func (g *Gateway) handleListTiers(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"tiers": sandbox.ListTiers()})
 }
 
+func (g *Gateway) handleOpenClawSessions(w http.ResponseWriter, r *http.Request) {
+	if g.sandboxes == nil {
+		writeJSON(w, http.StatusOK, map[string]any{"sessions": []any{}})
+		return
+	}
+
+	output, err := g.sandboxes.ExecOpenClawCommand(r.Context(), []string{"sessions", "--json"})
+	if err != nil {
+		writeJSON(w, http.StatusOK, map[string]any{"sessions": []any{}})
+		return
+	}
+
+	// Forward the raw JSON from OpenClaw
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(output))
+}
+
+func (g *Gateway) handleOpenClawUI(w http.ResponseWriter, r *http.Request) {
+	if g.sandboxes == nil {
+		writeError(w, http.StatusServiceUnavailable, "sandbox management not available")
+		return
+	}
+
+	containerIP, err := g.sandboxes.OpenClawContainerIP(r.Context())
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, "OpenClaw is not running")
+		return
+	}
+
+	// Redirect to the OpenClaw control UI inside the container
+	uiURL := fmt.Sprintf("http://%s:18789/#token=solon-openclaw-token", containerIP)
+	http.Redirect(w, r, uiURL, http.StatusTemporaryRedirect)
+}
+
 // stripDockerLogHeaders removes the 8-byte Docker multiplex log headers.
 // Docker log format: [stream_type(1) 0 0 0 size(4)] payload
 func stripDockerLogHeaders(data []byte) []byte {

--- a/internal/gateway/sandbox_handlers.go
+++ b/internal/gateway/sandbox_handlers.go
@@ -193,7 +193,9 @@ func (g *Gateway) handleOpenClawSend(w http.ResponseWriter, r *http.Request) {
 
 	// Parse the message from the request body
 	var req struct {
-		Message string `json:"message"`
+		Message  string `json:"message"`
+		Agent    string `json:"agent"`
+		Thinking string `json:"thinking"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Message == "" {
 		writeError(w, http.StatusBadRequest, "message is required")
@@ -201,7 +203,15 @@ func (g *Gateway) handleOpenClawSend(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Run openclaw agent directly via docker exec (bypasses buggy agent-api bridge)
-	output, err := g.sandboxes.ExecOpenClawAgent(r.Context(), req.Message)
+	agent := req.Agent
+	if agent == "" {
+		agent = "main"
+	}
+	args := []string{"agent", "--agent", agent, "--message", req.Message, "--json", "--timeout", "180"}
+	if req.Thinking != "" && req.Thinking != "off" {
+		args = append(args, "--thinking", req.Thinking)
+	}
+	output, err := g.sandboxes.ExecOpenClawCommand(r.Context(), args)
 	if err != nil {
 		writeError(w, http.StatusBadGateway, fmt.Sprintf("agent error: %v", err))
 		return

--- a/internal/gateway/sandbox_handlers.go
+++ b/internal/gateway/sandbox_handlers.go
@@ -373,15 +373,49 @@ func (g *Gateway) handleOpenClawChannels(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	output, err := g.sandboxes.ExecOpenClawCommand(r.Context(), []string{"channels", "list", "--json"})
+	output, err := g.sandboxes.ExecOpenClawCommand(r.Context(), []string{"channels", "status", "--json"})
 	if err != nil {
 		writeJSON(w, http.StatusOK, map[string]any{"channels": []any{}})
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write([]byte(output))
+	// Parse the status response and transform into a flat channels array
+	var status struct {
+		Channels map[string]struct {
+			Configured bool   `json:"configured"`
+			Running    bool   `json:"running"`
+			LastError  string `json:"lastError"`
+		} `json:"channels"`
+	}
+	if err := json.Unmarshal([]byte(output), &status); err != nil {
+		// Fallback: return raw output
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(output))
+		return
+	}
+
+	channels := make([]map[string]any, 0)
+	for name, ch := range status.Channels {
+		if !ch.Configured {
+			continue
+		}
+		s := "connected"
+		if !ch.Running {
+			s = "error"
+		}
+		entry := map[string]any{
+			"name":   name,
+			"type":   name,
+			"status": s,
+		}
+		if ch.LastError != "" {
+			entry["lastError"] = ch.LastError
+		}
+		channels = append(channels, entry)
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"channels": channels})
 }
 
 func (g *Gateway) handleOpenClawAddChannel(w http.ResponseWriter, r *http.Request) {

--- a/internal/gateway/sandbox_handlers.go
+++ b/internal/gateway/sandbox_handlers.go
@@ -399,7 +399,11 @@ func (g *Gateway) handleOpenClawAddChannel(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	output, err := g.sandboxes.ExecOpenClawCommand(r.Context(), []string{"channels", "add", "--channel", req.Channel, "--bot-token", req.BotToken})
+	args := []string{"channels", "add", "--channel", req.Channel}
+	if req.BotToken != "" {
+		args = append(args, "--token", req.BotToken)
+	}
+	output, err := g.sandboxes.ExecOpenClawCommand(r.Context(), args)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, fmt.Sprintf("channel add error: %v", err))
 		return

--- a/internal/gateway/sandbox_handlers.go
+++ b/internal/gateway/sandbox_handlers.go
@@ -357,6 +357,154 @@ func (g *Gateway) handleOpenClawSessions(w http.ResponseWriter, r *http.Request)
 	_, _ = w.Write([]byte(output))
 }
 
+func (g *Gateway) handleOpenClawChannels(w http.ResponseWriter, r *http.Request) {
+	if g.sandboxes == nil {
+		writeJSON(w, http.StatusOK, map[string]any{"channels": []any{}})
+		return
+	}
+
+	output, err := g.sandboxes.ExecOpenClawCommand(r.Context(), []string{"channels", "list", "--json"})
+	if err != nil {
+		writeJSON(w, http.StatusOK, map[string]any{"channels": []any{}})
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(output))
+}
+
+func (g *Gateway) handleOpenClawAddChannel(w http.ResponseWriter, r *http.Request) {
+	if g.sandboxes == nil {
+		writeError(w, http.StatusServiceUnavailable, "sandbox management not available")
+		return
+	}
+
+	var req struct {
+		Channel  string `json:"channel"`
+		BotToken string `json:"bot_token"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Channel == "" {
+		writeError(w, http.StatusBadRequest, "channel is required")
+		return
+	}
+
+	output, err := g.sandboxes.ExecOpenClawCommand(r.Context(), []string{"channels", "add", "--channel", req.Channel, "--bot-token", req.BotToken})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("channel add error: %v", err))
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"result": output})
+}
+
+func (g *Gateway) handleOpenClawRemoveChannel(w http.ResponseWriter, r *http.Request) {
+	if g.sandboxes == nil {
+		writeError(w, http.StatusServiceUnavailable, "sandbox management not available")
+		return
+	}
+
+	name := chi.URLParam(r, "name")
+	output, err := g.sandboxes.ExecOpenClawCommand(r.Context(), []string{"channels", "remove", "--channel", name})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("channel remove error: %v", err))
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"result": output})
+}
+
+func (g *Gateway) handleOpenClawAgents(w http.ResponseWriter, r *http.Request) {
+	if g.sandboxes == nil {
+		writeJSON(w, http.StatusOK, map[string]any{"agents": []any{}})
+		return
+	}
+
+	output, err := g.sandboxes.ExecOpenClawCommand(r.Context(), []string{"agents", "list", "--json"})
+	if err != nil {
+		writeJSON(w, http.StatusOK, map[string]any{"agents": []any{}})
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(output))
+}
+
+func (g *Gateway) handleOpenClawSkills(w http.ResponseWriter, r *http.Request) {
+	if g.sandboxes == nil {
+		writeJSON(w, http.StatusOK, map[string]any{"skills": []any{}})
+		return
+	}
+
+	output, err := g.sandboxes.ExecOpenClawCommand(r.Context(), []string{"skills", "list", "--json"})
+	if err != nil {
+		writeJSON(w, http.StatusOK, map[string]any{"skills": []any{}})
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(output))
+}
+
+var workspaceAllowlist = map[string]bool{
+	"SOUL.md":     true,
+	"IDENTITY.md": true,
+	"USER.md":     true,
+	"AGENTS.md":   true,
+}
+
+func (g *Gateway) handleOpenClawReadFile(w http.ResponseWriter, r *http.Request) {
+	if g.sandboxes == nil {
+		writeError(w, http.StatusServiceUnavailable, "sandbox management not available")
+		return
+	}
+
+	filename := chi.URLParam(r, "filename")
+	if !workspaceAllowlist[filename] {
+		writeError(w, http.StatusForbidden, "filename not allowed")
+		return
+	}
+
+	filePath := "/root/.openclaw/workspace/" + filename
+	content, err := g.sandboxes.ExecInContainer(r.Context(), []string{"cat", filePath})
+	if err != nil {
+		content = ""
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"filename": filename, "content": content})
+}
+
+func (g *Gateway) handleOpenClawWriteFile(w http.ResponseWriter, r *http.Request) {
+	if g.sandboxes == nil {
+		writeError(w, http.StatusServiceUnavailable, "sandbox management not available")
+		return
+	}
+
+	filename := chi.URLParam(r, "filename")
+	if !workspaceAllowlist[filename] {
+		writeError(w, http.StatusForbidden, "filename not allowed")
+		return
+	}
+
+	var req struct {
+		Content string `json:"content"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	filePath := "/root/.openclaw/workspace/" + filename
+	if err := g.sandboxes.WriteToContainer(r.Context(), filePath, req.Content); err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("write error: %v", err))
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "saved"})
+}
+
 func (g *Gateway) handleOpenClawUI(w http.ResponseWriter, r *http.Request) {
 	if g.sandboxes == nil {
 		writeError(w, http.StatusServiceUnavailable, "sandbox management not available")

--- a/internal/sandbox/manager.go
+++ b/internal/sandbox/manager.go
@@ -748,34 +748,6 @@ func (m *Manager) OpenClawContainerIP(ctx context.Context) (string, error) {
 	return "", fmt.Errorf("no running OpenClaw gateway container found")
 }
 
-// ExecOpenClawAgent runs the openclaw agent CLI inside the container and returns the JSON output.
-func (m *Manager) ExecOpenClawAgent(ctx context.Context, message string) (string, error) {
-	containers, err := m.docker.containerList(ctx, LabelManaged+"=true")
-	if err != nil {
-		return "", fmt.Errorf("listing containers: %w", err)
-	}
-
-	var containerID string
-	for _, c := range containers {
-		if c.Labels[LabelPolicy] == "openclaw-gateway" && c.State == "running" {
-			containerID = c.ID
-			break
-		}
-	}
-	if containerID == "" {
-		return "", fmt.Errorf("no running OpenClaw container found")
-	}
-
-	output, err := m.docker.containerExec(ctx, containerID,
-		[]string{"openclaw", "agent", "--agent", "main", "--message", message, "--json", "--timeout", "180"},
-		nil,
-	)
-	if err != nil {
-		return "", fmt.Errorf("exec openclaw agent: %w", err)
-	}
-	return output, nil
-}
-
 // ExecOpenClawCommand runs an arbitrary openclaw CLI command inside the container.
 func (m *Manager) ExecOpenClawCommand(ctx context.Context, args []string) (string, error) {
 	containers, err := m.docker.containerList(ctx, LabelManaged+"=true")

--- a/internal/sandbox/manager.go
+++ b/internal/sandbox/manager.go
@@ -776,6 +776,32 @@ func (m *Manager) ExecOpenClawAgent(ctx context.Context, message string) (string
 	return output, nil
 }
 
+// ExecOpenClawCommand runs an arbitrary openclaw CLI command inside the container.
+func (m *Manager) ExecOpenClawCommand(ctx context.Context, args []string) (string, error) {
+	containers, err := m.docker.containerList(ctx, LabelManaged+"=true")
+	if err != nil {
+		return "", fmt.Errorf("listing containers: %w", err)
+	}
+
+	var containerID string
+	for _, c := range containers {
+		if c.Labels[LabelPolicy] == "openclaw-gateway" && c.State == "running" {
+			containerID = c.ID
+			break
+		}
+	}
+	if containerID == "" {
+		return "", fmt.Errorf("no running OpenClaw container found")
+	}
+
+	cmd := append([]string{"openclaw"}, args...)
+	output, err := m.docker.containerExec(ctx, containerID, cmd, nil)
+	if err != nil {
+		return "", fmt.Errorf("exec openclaw %v: %w", args, err)
+	}
+	return output, nil
+}
+
 // Stats returns resource usage for a sandbox.
 func (m *Manager) Stats(ctx context.Context, id string) (*SandboxStats, error) {
 	sb, err := m.store.GetSandbox(id)

--- a/internal/sandbox/manager.go
+++ b/internal/sandbox/manager.go
@@ -802,6 +802,64 @@ func (m *Manager) ExecOpenClawCommand(ctx context.Context, args []string) (strin
 	return output, nil
 }
 
+// ExecInContainer runs a raw command (no "openclaw" prefix) inside the running
+// OpenClaw container. Same container-finding pattern as ExecOpenClawCommand.
+func (m *Manager) ExecInContainer(ctx context.Context, cmd []string) (string, error) {
+	containers, err := m.docker.containerList(ctx, LabelManaged+"=true")
+	if err != nil {
+		return "", fmt.Errorf("listing containers: %w", err)
+	}
+
+	var containerID string
+	for _, c := range containers {
+		if c.Labels[LabelPolicy] == "openclaw-gateway" && c.State == "running" {
+			containerID = c.ID
+			break
+		}
+	}
+	if containerID == "" {
+		return "", fmt.Errorf("no running OpenClaw container found")
+	}
+
+	output, err := m.docker.containerExec(ctx, containerID, cmd, nil)
+	if err != nil {
+		return "", fmt.Errorf("exec %v: %w", cmd, err)
+	}
+	return output, nil
+}
+
+// WriteToContainer writes content to a file inside the OpenClaw container using
+// sh -c with printf to avoid heredoc quoting issues.
+func (m *Manager) WriteToContainer(ctx context.Context, filePath string, content string) error {
+	containers, err := m.docker.containerList(ctx, LabelManaged+"=true")
+	if err != nil {
+		return fmt.Errorf("listing containers: %w", err)
+	}
+
+	var containerID string
+	for _, c := range containers {
+		if c.Labels[LabelPolicy] == "openclaw-gateway" && c.State == "running" {
+			containerID = c.ID
+			break
+		}
+	}
+	if containerID == "" {
+		return fmt.Errorf("no running OpenClaw container found")
+	}
+
+	// Use printf %s to safely write arbitrary content without shell interpretation
+	// Escape single quotes in the content by ending the quote, inserting a literal
+	// single quote, then reopening the quote.
+	escaped := strings.ReplaceAll(content, "'", "'\\''")
+	shCmd := fmt.Sprintf("printf '%%s' '%s' > '%s'", escaped, filePath)
+
+	_, err = m.docker.containerExec(ctx, containerID, []string{"sh", "-c", shCmd}, nil)
+	if err != nil {
+		return fmt.Errorf("writing file %s: %w", filePath, err)
+	}
+	return nil
+}
+
 // Stats returns resource usage for a sandbox.
 func (m *Manager) Stats(ctx context.Context, id string) (*SandboxStats, error) {
 	sb, err := m.store.GetSandbox(id)


### PR DESCRIPTION
## Summary

Completes the agent track with all remaining dashboard features for the OpenClaw agent experience:

- **Backend API endpoints** — channels, agents, skills, and workspace file proxy endpoints via OpenClaw CLI (`docker exec`)
- **Agent Settings page** (#28) — tabbed UI with Model, Channels, Workspace editor, Skills, and Access sections
- **Telegram channel connect** (#29) — BotFather flow with token input, connect/disconnect from dashboard
- **Conversation sidebar** (#30) — session list in Chat using OpenClaw sessions, with New Chat button
- **Chat header controls** (#31) — agent selector dropdown, thinking level toggle (Off/Low/Medium/High)
- **Home page** — action card now links to Agent Settings instead of generic settings

Closes #28, #29, #30, #31

## Test plan

- [ ] Navigate to Agent Settings from sidebar
- [ ] Verify Model tab shows current agent model
- [ ] Switch to Channels tab, connect a Telegram bot via token
- [ ] Verify connected channel appears with green status dot
- [ ] Switch to Workspace tab, edit SOUL.md, save, reload — content persists
- [ ] Open Chat — verify conversation sidebar shows sessions
- [ ] Toggle sidebar with the panel icon button
- [ ] Click "New" to start a fresh conversation
- [ ] Verify thinking level selector appears in agent mode
- [ ] Send a message with different thinking levels
- [ ] Verify agent selector only appears when multiple agents exist
- [ ] Home page "Agent Settings" card links to /agent-settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)