### PR TITLE
fix: add Cache-Control headers to prevent stale dashboard

### DIFF
--- a/dashboard/public/_headers
+++ b/dashboard/public/_headers
@@ -1,0 +1,5 @@
+/index.html
+  Cache-Control: no-cache, must-revalidate
+
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable


### PR DESCRIPTION
## Summary
- Adds `_headers` file for Cloudflare Pages to set proper cache directives
- `index.html` gets `no-cache, must-revalidate` — forces browser to always check for new version
- `/assets/*` gets `immutable` with 1-year TTL — safe because Vite hashes filenames

## Test plan
- [ ] Deploy to Cloudflare Pages
- [ ] `curl -I https://app.getsolon.dev` — verify `Cache-Control: no-cache` on HTML
- [ ] `curl -I https://app.getsolon.dev/assets/index-*.js` — verify `immutable`
- [ ] Load app, deploy new version, verify single refresh shows new version

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)