### PR TITLE
fix: add rows.Err() checks to all SQLite query loops

### DIFF
--- a/internal/storage/analytics.go
+++ b/internal/storage/analytics.go
@@ -71,6 +71,10 @@ func (d *DB) GetRequestLog(limit int) ([]RequestLog, error) {
 		logs = append(logs, log)
 	}
 
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating request log: %w", err)
+	}
+
 	return logs, nil
 }
 

--- a/internal/storage/guardrails.go
+++ b/internal/storage/guardrails.go
@@ -61,6 +61,10 @@ func (d *DB) GetGuardrailEvents(limit int) ([]GuardrailEvent, error) {
 		events = append(events, e)
 	}
 
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating guardrail events: %w", err)
+	}
+
 	return events, nil
 }
 

--- a/internal/storage/guardrails_test.go
+++ b/internal/storage/guardrails_test.go
@@ -1,0 +1,71 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogGuardrailEvent(t *testing.T) {
+	db := testDB(t)
+
+	err := db.LogGuardrailEvent("req-1", "key-1", "llama3.2:8b", "gate", "pass", "", 0.0)
+	require.NoError(t, err)
+
+	events, err := db.GetGuardrailEvents(10)
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+
+	assert.Equal(t, "req-1", events[0].RequestID)
+	assert.Equal(t, "key-1", events[0].KeyID)
+	assert.Equal(t, "llama3.2:8b", events[0].Model)
+	assert.Equal(t, "gate", events[0].Stage)
+	assert.Equal(t, "pass", events[0].Action)
+}
+
+func TestGetGuardrailEventsLimit(t *testing.T) {
+	db := testDB(t)
+
+	for i := 0; i < 5; i++ {
+		err := db.LogGuardrailEvent("req-x", "", "", "gate", "pass", "", 0.0)
+		require.NoError(t, err)
+	}
+
+	events, err := db.GetGuardrailEvents(3)
+	require.NoError(t, err)
+	assert.Len(t, events, 3)
+
+	events, err = db.GetGuardrailEvents(100)
+	require.NoError(t, err)
+	assert.Len(t, events, 5)
+}
+
+func TestGetGuardrailEventsEmpty(t *testing.T) {
+	db := testDB(t)
+
+	events, err := db.GetGuardrailEvents(10)
+	require.NoError(t, err)
+	assert.Empty(t, events)
+}
+
+func TestGetGuardrailStats(t *testing.T) {
+	db := testDB(t)
+
+	// Empty stats
+	stats, err := db.GetGuardrailStats()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), stats["total_events"])
+
+	// Log events with different actions
+	_ = db.LogGuardrailEvent("req-1", "", "", "gate", "pass", "", 0.0)
+	_ = db.LogGuardrailEvent("req-2", "", "", "shield", "block", "toxic content", 0.95)
+	_ = db.LogGuardrailEvent("req-3", "", "", "policy", "flag", "sensitive topic", 0.6)
+	_ = db.LogGuardrailEvent("req-4", "", "", "gate", "pass", "", 0.0)
+
+	stats, err = db.GetGuardrailStats()
+	require.NoError(t, err)
+	assert.Equal(t, int64(4), stats["total_events"])
+	assert.Equal(t, int64(1), stats["blocked"])
+	assert.Equal(t, int64(1), stats["flagged"])
+}

--- a/internal/storage/keys.go
+++ b/internal/storage/keys.go
@@ -178,6 +178,10 @@ func (d *DB) ValidateKey(rawKey string) (*APIKey, error) {
 		}
 	}
 
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating keys for validation: %w", err)
+	}
+
 	return nil, fmt.Errorf("invalid API key")
 }
 
@@ -214,6 +218,10 @@ func (d *DB) ListKeys() ([]APIKey, error) {
 		}
 
 		keys = append(keys, key)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating keys: %w", err)
 	}
 
 	return keys, nil
@@ -274,10 +282,15 @@ func (d *DB) GetUsageByKey() (map[string]KeyUsage, error) {
 		var keyID string
 		var usage KeyUsage
 		if err := rows.Scan(&keyID, &usage.RequestCount, &usage.TotalTokens); err != nil {
-			continue
+			return nil, fmt.Errorf("scanning usage by key: %w", err)
 		}
 		result[keyID] = usage
 	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating usage by key: %w", err)
+	}
+
 	return result, nil
 }
 

--- a/internal/storage/keys_test.go
+++ b/internal/storage/keys_test.go
@@ -226,6 +226,32 @@ func TestHasKeys(t *testing.T) {
 	assert.False(t, has)
 }
 
+func TestGetUsageByKey(t *testing.T) {
+	db := testDB(t)
+
+	// Empty usage
+	usage, err := db.GetUsageByKey()
+	require.NoError(t, err)
+	assert.Empty(t, usage)
+
+	// Create keys and log requests
+	key1, _ := db.CreateKey("key-1", "user")
+	key2, _ := db.CreateKey("key-2", "user")
+
+	_ = db.LogRequest(key1.ID, "POST", "/v1/chat/completions", "llama3.2:8b", 100, 50, 200, 200, "")
+	_ = db.LogRequest(key1.ID, "POST", "/v1/chat/completions", "llama3.2:8b", 200, 100, 300, 200, "")
+	_ = db.LogRequest(key2.ID, "POST", "/v1/embeddings", "nomic-embed-text", 50, 0, 50, 200, "")
+
+	usage, err = db.GetUsageByKey()
+	require.NoError(t, err)
+	assert.Len(t, usage, 2)
+
+	assert.Equal(t, int64(2), usage[key1.ID].RequestCount)
+	assert.Equal(t, int64(450), usage[key1.ID].TotalTokens) // (100+50) + (200+100)
+	assert.Equal(t, int64(1), usage[key2.ID].RequestCount)
+	assert.Equal(t, int64(50), usage[key2.ID].TotalTokens)
+}
+
 func TestOpenDefaultPath(t *testing.T) {
 	// Override HOME to temp dir to avoid touching real home
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary
- Added missing `rows.Err()` checks after `for rows.Next()` loops in analytics, keys, and guardrails storage
- Changed `GetUsageByKey` to return scan errors instead of silently skipping with `continue`
- Added test coverage for `GetUsageByKey` and full guardrail event CRUD

## Files changed
- `internal/storage/analytics.go` — `GetRequestLog`
- `internal/storage/keys.go` — `ListKeys`, `ValidateKey`, `GetUsageByKey`
- `internal/storage/guardrails.go` — `GetGuardrailEvents`
- `internal/storage/keys_test.go` — new `TestGetUsageByKey`
- `internal/storage/guardrails_test.go` — new file with 4 test functions

## Test plan
- [x] `go test ./internal/storage/ -v` — 31 tests pass
- [x] All existing tests continue to pass (no behavior change on happy path)
- [x] New tests cover the previously untested functions

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)