### PR TITLE
fix: add Error Boundary and handle async errors in dashboard

### DIFF
--- a/dashboard/src/components/ErrorBoundary.tsx
+++ b/dashboard/src/components/ErrorBoundary.tsx
@@ -1,0 +1,51 @@
+import { Component } from 'react'
+import type { ReactNode, ErrorInfo } from 'react'
+import Button from './Button'
+
+interface Props {
+  children: ReactNode
+}
+
+interface State {
+  hasError: boolean
+  error: Error | null
+}
+
+export default class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false, error: null }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('ErrorBoundary caught:', error, info.componentStack)
+  }
+
+  handleReset = () => {
+    this.setState({ hasError: false, error: null })
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex items-center justify-center min-h-screen bg-[var(--bg-primary)]">
+          <div className="text-center space-y-4 max-w-md px-6">
+            <h1 className="text-xl font-semibold text-[var(--text-primary)]">Something went wrong</h1>
+            <p className="text-sm text-[var(--text-secondary)]">
+              {this.state.error?.message || 'An unexpected error occurred.'}
+            </p>
+            <div className="flex gap-2 justify-center">
+              <Button onClick={this.handleReset} size="sm">Try again</Button>
+              <Button variant="secondary" size="sm" onClick={() => window.location.reload()}>
+                Reload page
+              </Button>
+            </div>
+          </div>
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -2,12 +2,15 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import App from './App'
+import ErrorBoundary from './components/ErrorBoundary'
 import './index.css'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <ErrorBoundary>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </ErrorBoundary>
   </StrictMode>,
 )

--- a/dashboard/src/pages/instance/Chat.tsx
+++ b/dashboard/src/pages/instance/Chat.tsx
@@ -78,7 +78,8 @@ export default function Chat() {
     }
   }
 
-  useEffect(() => { connect() }, [])
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => { connect().catch(() => setMode('disconnected')) }, [])
 
   async function handleSend() {
     const text = input.trim()

--- a/internal/gateway/sandbox_handlers.go
+++ b/internal/gateway/sandbox_handlers.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"time"
 
 	"github.com/go-chi/chi/v5"
 


### PR DESCRIPTION
## Summary
- Added `ErrorBoundary` component wrapping the app root — catches React render errors and shows recovery UI instead of blank screen
- Fixed unhandled promise rejection in `Chat.tsx` useEffect — `connect()` failures now set mode to `disconnected` instead of silently rejecting

## Test plan
- [x] `npx tsc --noEmit` — clean typecheck
- [x] `npm run build` — production build succeeds
- [ ] Trigger a render error in dev — verify ErrorBoundary shows "Something went wrong" with retry/reload buttons
- [ ] Test Chat page with unreachable instance — verify graceful disconnected state

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)