### PR TITLE
chore: add cloud API tests and TypeScript checks to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,20 @@ jobs:
       - name: Verify dashboard build
         run: test -f internal/dashboard/dist/index.html || (echo "Dashboard build missing index.html" && exit 1)
 
-      - name: Test
+      - name: Test Go
         run: make test
+
+      - name: Test cloud API
+        run: cd cloud && npm ci && npm run test
+
+      - name: Typecheck cloud API
+        run: cd cloud && npm run typecheck
+
+      - name: Typecheck provisioner
+        run: cd provisioner && npm ci && npm run typecheck
+
+      - name: Typecheck relay
+        run: cd relay && npm ci && npx tsc --noEmit
 
       - name: Lint
         uses: golangci/golangci-lint-action@v7

--- a/relay/src/index.ts
+++ b/relay/src/index.ts
@@ -252,7 +252,7 @@ export class SolonInstance implements DurableObject {
       case 'response': {
         const pending = this.pending.get(msg.id!);
         if (pending) {
-          pending.resolve(msg as RelayResponse);
+          pending.resolve(msg as unknown as RelayResponse);
         }
         break;
       }
@@ -260,7 +260,7 @@ export class SolonInstance implements DurableObject {
       case 'response_start': {
         const pending = this.pending.get(msg.id!);
         if (pending) {
-          pending.resolve(msg as RelayResponse);
+          pending.resolve(msg as unknown as RelayResponse);
         }
         break;
       }


### PR DESCRIPTION
## Summary
- Added cloud API vitest suite to CI (12 tests, currently the only cloud tests)
- Added TypeScript typecheck for cloud API, provisioner, and relay
- Fixed 2 type errors in `relay/src/index.ts` (`RelayMessage` → `RelayResponse` cast needed `unknown` intermediate)

## Before
CI only ran `make test` (Go) and `golangci-lint`. Node.js code shipped without any CI validation.

## After
```yaml
- Test Go          # make test
- Test cloud API   # cd cloud && npm run test
- Typecheck cloud  # cd cloud && npm run typecheck
- Typecheck provisioner
- Typecheck relay
- Lint             # golangci-lint
```

## Test plan
- [x] Cloud API tests pass locally (12/12)
- [x] All 4 typechecks pass locally (cloud, provisioner, relay, dashboard)
- [ ] CI pipeline succeeds on this PR

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)