### PR TITLE
fix: make OpenClaw UI reachable via HTTP reverse proxy

### DIFF
--- a/dashboard/src/pages/instance/OpenClawUI.tsx
+++ b/dashboard/src/pages/instance/OpenClawUI.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { fetchJSON } from '../../api/client'
+import { fetchJSON, getLocalApiKey, isNonLocalhost } from '../../api/client'
 
 export default function OpenClawUI() {
   const navigate = useNavigate()
@@ -11,9 +11,14 @@ export default function OpenClawUI() {
     fetchJSON<{ available: boolean; running: boolean }>('/api/v1/openclaw/status')
       .then(s => {
         if (s.running) {
-          // The gateway control UI is accessible via the container's IP
-          // We proxy it through Solon's gateway
-          setUiUrl('/api/v1/openclaw/ui')
+          // Proxy the OpenClaw control UI through Solon's gateway.
+          // On non-localhost we pass the API key as ?token= so the proxy
+          // can authenticate and set a cookie for subsequent asset requests.
+          const apiKey = isNonLocalhost() ? getLocalApiKey() : null
+          const url = apiKey
+            ? `/api/v1/openclaw/ui?token=${encodeURIComponent(apiKey)}`
+            : '/api/v1/openclaw/ui'
+          setUiUrl(url)
         } else {
           setError('OpenClaw agent is not running. Start it from the Dashboard first.')
         }

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -173,7 +173,6 @@ func (g *Gateway) setupRoutes() {
 		r.Get("/api/v1/openclaw/status", g.handleOpenClawStatus)
 		r.Post("/api/v1/openclaw/send", g.handleOpenClawSend)
 		r.Get("/api/v1/openclaw/sessions", g.handleOpenClawSessions)
-		r.Get("/api/v1/openclaw/ui", g.handleOpenClawUI)
 		r.Get("/api/v1/openclaw/channels", g.handleOpenClawChannels)
 		r.Post("/api/v1/openclaw/channels", g.handleOpenClawAddChannel)
 		r.Delete("/api/v1/openclaw/channels/{name}", g.handleOpenClawRemoveChannel)
@@ -189,6 +188,16 @@ func (g *Gateway) setupRoutes() {
 		r.Use(g.LocalhostOrAuth)
 		r.Use(g.RequireAdminScope)
 		r.Get("/api/v1/openclaw/ws", g.handleOpenClawWS)
+	})
+
+	// OpenClaw UI reverse proxy (separate group for cookie/query auth support
+	// — iframes can't set custom headers, so we authenticate via cookie or ?token=)
+	r.Group(func(r chi.Router) {
+		r.Use(UIAuthFromCookieOrQuery)
+		r.Use(g.LocalhostOrAuth)
+		r.Use(g.RequireAdminScope)
+		r.Handle("/api/v1/openclaw/ui", http.HandlerFunc(g.handleOpenClawUIProxy))
+		r.Handle("/api/v1/openclaw/ui/*", http.HandlerFunc(g.handleOpenClawUIProxy))
 	})
 
 	// Dashboard — serve embedded static files (no auth, localhost only)

--- a/internal/gateway/sandbox_handlers.go
+++ b/internal/gateway/sandbox_handlers.go
@@ -550,6 +550,7 @@ func (g *Gateway) handleOpenClawUIProxy(w http.ResponseWriter, r *http.Request) 
 			Value:    token,
 			Path:     "/api/v1/openclaw/ui",
 			HttpOnly: true,
+			Secure:   r.TLS != nil,
 			SameSite: http.SameSiteStrictMode,
 			MaxAge:   3600, // 1 hour
 		})

--- a/internal/gateway/sandbox_handlers.go
+++ b/internal/gateway/sandbox_handlers.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 
@@ -495,7 +498,16 @@ func (g *Gateway) handleOpenClawWriteFile(w http.ResponseWriter, r *http.Request
 	writeJSON(w, http.StatusOK, map[string]string{"status": "saved"})
 }
 
-func (g *Gateway) handleOpenClawUI(w http.ResponseWriter, r *http.Request) {
+// handleOpenClawUIProxy reverse-proxies HTTP requests to the OpenClaw control UI
+// running inside the Docker container. The prefix "/api/v1/openclaw/ui" is stripped
+// before forwarding so relative asset paths like "./assets/foo.js" resolve correctly
+// under the same proxy path (browser requests /api/v1/openclaw/ui/assets/foo.js which
+// becomes /assets/foo.js upstream).
+//
+// Auth: browser iframes can't set custom headers, so UIAuthFromCookieOrQuery middleware
+// converts ?token=<key> or cookie "solon-ui-token" into the Authorization header before
+// the normal auth middleware validates.
+func (g *Gateway) handleOpenClawUIProxy(w http.ResponseWriter, r *http.Request) {
 	if g.sandboxes == nil {
 		writeError(w, http.StatusServiceUnavailable, "sandbox management not available")
 		return
@@ -503,13 +515,47 @@ func (g *Gateway) handleOpenClawUI(w http.ResponseWriter, r *http.Request) {
 
 	containerIP, err := g.sandboxes.OpenClawContainerIP(r.Context())
 	if err != nil {
-		writeError(w, http.StatusServiceUnavailable, "OpenClaw is not running")
+		writeError(w, http.StatusServiceUnavailable, "OpenClaw is not running — start it first via the dashboard or 'solon openclaw'")
 		return
 	}
 
-	// Redirect to the OpenClaw control UI inside the container
-	uiURL := fmt.Sprintf("http://%s:18789/#token=solon-openclaw-token", containerIP)
-	http.Redirect(w, r, uiURL, http.StatusTemporaryRedirect)
+	upstream, err := url.Parse(fmt.Sprintf("http://%s:%d", containerIP, openclawGatewayPort))
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("invalid upstream URL: %v", err))
+		return
+	}
+
+	proxy := httputil.NewSingleHostReverseProxy(upstream)
+	origDirector := proxy.Director
+	proxy.Director = func(req *http.Request) {
+		origDirector(req)
+		// Strip the route prefix so upstream sees paths like /, /assets/foo.js
+		req.URL.Path = strings.TrimPrefix(req.URL.Path, "/api/v1/openclaw/ui")
+		if req.URL.Path == "" {
+			req.URL.Path = "/"
+		}
+		req.Host = upstream.Host
+		// Remove Solon-specific auth — upstream runs with --auth none
+		req.Header.Del("Authorization")
+	}
+	proxy.ErrorHandler = func(rw http.ResponseWriter, _ *http.Request, err error) {
+		writeError(rw, http.StatusBadGateway, fmt.Sprintf("OpenClaw UI proxy error: %v", err))
+	}
+
+	// Set a short-lived cookie on the initial HTML load so subsequent
+	// asset/API requests from the iframe authenticate automatically.
+	if token := r.URL.Query().Get("token"); token != "" {
+		http.SetCookie(w, &http.Cookie{
+			Name:     "solon-ui-token",
+			Value:    token,
+			Path:     "/api/v1/openclaw/ui",
+			HttpOnly: true,
+			SameSite: http.SameSiteStrictMode,
+			MaxAge:   3600, // 1 hour
+		})
+	}
+
+	proxy.ServeHTTP(w, r)
 }
 
 // stripDockerLogHeaders removes the 8-byte Docker multiplex log headers.

--- a/internal/gateway/ws_proxy.go
+++ b/internal/gateway/ws_proxy.go
@@ -37,6 +37,24 @@ func WSAuthFromQueryParam(next http.Handler) http.Handler {
 	})
 }
 
+// UIAuthFromCookieOrQuery extracts a token from the "solon-ui-token" cookie
+// or the ?token= query parameter and sets it as the Authorization header.
+// This allows browser iframe/asset requests to authenticate (iframes can't
+// set custom headers; cookies are the only same-origin auth mechanism
+// automatically included by the browser).
+func UIAuthFromCookieOrQuery(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			if token := r.URL.Query().Get("token"); token != "" {
+				r.Header.Set("Authorization", "Bearer "+token)
+			} else if c, err := r.Cookie("solon-ui-token"); err == nil && c.Value != "" {
+				r.Header.Set("Authorization", "Bearer "+c.Value)
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
 // handleOpenClawWS upgrades an HTTP connection to WebSocket and proxies
 // it bidirectionally to the OpenClaw gateway inside the Docker container.
 // Auth is validated by middleware BEFORE this handler is called.

--- a/internal/sandbox/manager.go
+++ b/internal/sandbox/manager.go
@@ -678,7 +678,12 @@ func (m *Manager) EnsureOpenClaw(ctx context.Context, providerKey string) (*Open
 						"server.listen(PORT, '0.0.0.0', () => console.log('[agent-api] listening on 0.0.0.0:' + PORT));\n"+
 						"API\n"+
 						// Start gateway on loopback (openclaw agent connects locally)
-						"openclaw gateway --port %d --bind loopback --allow-unconfigured --auth none &"+
+						// --bind lan: accept connections from the Docker bridge network so Solon
+						// can reverse-proxy the control UI. OpenClaw refuses lan binding without
+						// auth; we use the OPENCLAW_GATEWAY_TOKEN env var (already set above) as
+						// the internal token — Solon validates the user's API key at the proxy
+						// boundary before forwarding.
+						"openclaw gateway --port %d --bind lan --allow-unconfigured &"+
 						" sleep 5; "+
 						"exec node /tmp/agent-api.mjs",
 					gatewayPort+1, gatewayPort,


### PR DESCRIPTION
## Summary

The dashboard's OpenClaw UI page was broken end-to-end. Three compounding issues:

1. The handler did `http.Redirect` to `http://172.x.x.x:18789` — a Docker-internal IP unreachable from the client's browser.
2. The endpoint required a Bearer header, which iframes cannot send on direct navigation.
3. The OpenClaw gateway was bound to `--bind loopback`, so it wasn't reachable from Solon on the Docker bridge even if the redirect worked.

## Fix

- **HTTP reverse proxy** — replace redirect with `httputil.ReverseProxy` that forwards `/api/v1/openclaw/ui/*` to the container, stripping the prefix so relative asset paths resolve.
- **Cookie-based auth for iframes** — new `UIAuthFromCookieOrQuery` middleware accepts `?token=<key>` on the initial HTML load (sets an httpOnly cookie) and reads the cookie on subsequent asset requests. Mirrors the existing `WSAuthFromQueryParam` pattern.
- **LAN bind on the gateway** — `EnsureOpenClaw` now starts OpenClaw with `--bind lan` so Solon can reach it over the Docker bridge. OpenClaw's own token auth (`OPENCLAW_GATEWAY_TOKEN`) protects the internal port; Solon validates the user's API key at the proxy boundary.

## Test plan

- [x] `GET /api/v1/openclaw/ui?token=<key>` returns HTML (200)
- [x] Asset requests with cookie return 200
- [x] Asset requests without cookie return 401
- [x] Deployed to test server (178.104.104.13), verified end-to-end
- [ ] Open `/openclaw` in the dashboard browser — iframe renders the control panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)