### PR TITLE
fix: allow OpenClaw UI iframe embedding via same-origin proxy

### DIFF
--- a/internal/gateway/sandbox_handlers.go
+++ b/internal/gateway/sandbox_handlers.go
@@ -541,6 +541,17 @@ func (g *Gateway) handleOpenClawUIProxy(w http.ResponseWriter, r *http.Request) 
 	proxy.ErrorHandler = func(rw http.ResponseWriter, _ *http.Request, err error) {
 		writeError(rw, http.StatusBadGateway, fmt.Sprintf("OpenClaw UI proxy error: %v", err))
 	}
+	// OpenClaw sets X-Frame-Options: DENY and CSP frame-ancestors 'none' to
+	// prevent clickjacking. We embed the UI in a same-origin iframe, so rewrite
+	// these headers to allow 'self' embedding.
+	proxy.ModifyResponse = func(resp *http.Response) error {
+		resp.Header.Del("X-Frame-Options")
+		if csp := resp.Header.Get("Content-Security-Policy"); csp != "" {
+			resp.Header.Set("Content-Security-Policy",
+				strings.ReplaceAll(csp, "frame-ancestors 'none'", "frame-ancestors 'self'"))
+		}
+		return nil
+	}
 
 	// Set a short-lived cookie on the initial HTML load so subsequent
 	// asset/API requests from the iframe authenticate automatically.


### PR DESCRIPTION
## Summary

Follow-up to #55. The proxy was working but the iframe showed \"refused to connect\" because OpenClaw sets two clickjacking-protection headers:
- \`X-Frame-Options: DENY\`
- \`Content-Security-Policy: frame-ancestors 'none'\`

Since the dashboard embeds the UI on the same origin (proxy path), we strip/rewrite these headers to allow \`'self'\` embedding.

## Change

Add \`ModifyResponse\` to the reverse proxy that:
- Deletes \`X-Frame-Options\` entirely
- Replaces \`frame-ancestors 'none'\` with \`frame-ancestors 'self'\` in the CSP

## Test plan

- [x] \`X-Frame-Options\` absent from proxied response
- [x] CSP shows \`frame-ancestors 'self'\`
- [x] Deployed to test server, iframe loads the control panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)