### PR TITLE
fix: trailing slash + blob worker-src for OpenClaw UI

### DIFF
--- a/dashboard/src/pages/instance/OpenClawUI.tsx
+++ b/dashboard/src/pages/instance/OpenClawUI.tsx
@@ -15,9 +15,12 @@ export default function OpenClawUI() {
           // On non-localhost we pass the API key as ?token= so the proxy
           // can authenticate and set a cookie for subsequent asset requests.
           const apiKey = isNonLocalhost() ? getLocalApiKey() : null
+          // Trailing slash matters — the OpenClaw UI uses relative asset paths
+          // (./assets/*) that must resolve under /api/v1/openclaw/ui/ to stay
+          // inside the proxy route prefix.
           const url = apiKey
-            ? `/api/v1/openclaw/ui?token=${encodeURIComponent(apiKey)}`
-            : '/api/v1/openclaw/ui'
+            ? `/api/v1/openclaw/ui/?token=${encodeURIComponent(apiKey)}`
+            : '/api/v1/openclaw/ui/'
           setUiUrl(url)
         } else {
           setError('OpenClaw agent is not running. Start it from the Dashboard first.')

--- a/internal/gateway/sandbox_handlers.go
+++ b/internal/gateway/sandbox_handlers.go
@@ -513,6 +513,18 @@ func (g *Gateway) handleOpenClawUIProxy(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// Ensure trailing slash on the root UI path so the browser resolves
+	// relative asset URLs (./assets/foo.js) against /api/v1/openclaw/ui/
+	// instead of /api/v1/openclaw/ (which would miss the proxy prefix).
+	if r.URL.Path == "/api/v1/openclaw/ui" {
+		target := "/api/v1/openclaw/ui/"
+		if r.URL.RawQuery != "" {
+			target += "?" + r.URL.RawQuery
+		}
+		http.Redirect(w, r, target, http.StatusTemporaryRedirect)
+		return
+	}
+
 	containerIP, err := g.sandboxes.OpenClawContainerIP(r.Context())
 	if err != nil {
 		writeError(w, http.StatusServiceUnavailable, "OpenClaw is not running — start it first via the dashboard or 'solon openclaw'")
@@ -541,14 +553,19 @@ func (g *Gateway) handleOpenClawUIProxy(w http.ResponseWriter, r *http.Request) 
 	proxy.ErrorHandler = func(rw http.ResponseWriter, _ *http.Request, err error) {
 		writeError(rw, http.StatusBadGateway, fmt.Sprintf("OpenClaw UI proxy error: %v", err))
 	}
-	// OpenClaw sets X-Frame-Options: DENY and CSP frame-ancestors 'none' to
-	// prevent clickjacking. We embed the UI in a same-origin iframe, so rewrite
-	// these headers to allow 'self' embedding.
+	// Rewrite OpenClaw's response CSP/frame headers so the UI can be embedded
+	// in a same-origin iframe and still load its own blob-based web worker.
 	proxy.ModifyResponse = func(resp *http.Response) error {
 		resp.Header.Del("X-Frame-Options")
 		if csp := resp.Header.Get("Content-Security-Policy"); csp != "" {
-			resp.Header.Set("Content-Security-Policy",
-				strings.ReplaceAll(csp, "frame-ancestors 'none'", "frame-ancestors 'self'"))
+			csp = strings.ReplaceAll(csp, "frame-ancestors 'none'", "frame-ancestors 'self'")
+			// OpenClaw creates a web worker from a blob URL; add worker-src
+			// if not already set (script-src would otherwise be used as fallback
+			// and 'self' doesn't cover blob:).
+			if !strings.Contains(csp, "worker-src") {
+				csp = strings.TrimSuffix(csp, ";") + "; worker-src 'self' blob:"
+			}
+			resp.Header.Set("Content-Security-Policy", csp)
 		}
 		return nil
 	}


### PR DESCRIPTION
## Summary

Follow-up to #55/#56. After the iframe headers were fixed, the UI still didn't render because:

1. The proxy URL `/api/v1/openclaw/ui` (no trailing slash) caused the browser to resolve the HTML's relative asset paths (`./assets/foo.js`) against `/api/v1/openclaw/` — outside the proxy prefix. Assets fell through to the dashboard SPA handler and were served as `text/html`, breaking module loading.

2. OpenClaw creates a web worker from a `blob:` URL. CSP had no `worker-src`, so `script-src` applied as fallback, and `'self'` doesn't cover `blob:`.

## Fix

- Redirect `/api/v1/openclaw/ui` → `/api/v1/openclaw/ui/` (307)
- Frontend requests the trailing-slash form directly
- Append `worker-src 'self' blob:` to the rewritten CSP if not already set

## Test plan

- [x] No-slash URL returns 307 redirect to slash form
- [x] Asset requests return `application/javascript` (was `text/html`)
- [x] CSP contains `worker-src 'self' blob:`

🤖 Generated with [Claude Code](https://claude.com/claude-code)