### PR TITLE
fix: proxy WebSocket upgrades through the OpenClaw UI handler

### DIFF
--- a/internal/gateway/sandbox_handlers.go
+++ b/internal/gateway/sandbox_handlers.go
@@ -513,6 +513,25 @@ func (g *Gateway) handleOpenClawUIProxy(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	containerIP, err := g.sandboxes.OpenClawContainerIP(r.Context())
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, "OpenClaw is not running — start it first via the dashboard or 'solon openclaw'")
+		return
+	}
+
+	// WebSocket upgrade — the OpenClaw UI's client-side JS opens a WS to this
+	// path. Proxy it to the gateway (same port as HTTP; OpenClaw serves both
+	// protocols on 18789). Must run BEFORE the trailing-slash redirect since
+	// WS clients don't follow 307s.
+	if isWebSocketUpgrade(r) {
+		upstreamURL := fmt.Sprintf("ws://%s:%d", containerIP, openclawGatewayPort)
+		if r.URL.RawQuery != "" {
+			upstreamURL += "?" + r.URL.RawQuery
+		}
+		g.proxyWS(w, r, upstreamURL)
+		return
+	}
+
 	// Ensure trailing slash on the root UI path so the browser resolves
 	// relative asset URLs (./assets/foo.js) against /api/v1/openclaw/ui/
 	// instead of /api/v1/openclaw/ (which would miss the proxy prefix).
@@ -522,12 +541,6 @@ func (g *Gateway) handleOpenClawUIProxy(w http.ResponseWriter, r *http.Request) 
 			target += "?" + r.URL.RawQuery
 		}
 		http.Redirect(w, r, target, http.StatusTemporaryRedirect)
-		return
-	}
-
-	containerIP, err := g.sandboxes.OpenClawContainerIP(r.Context())
-	if err != nil {
-		writeError(w, http.StatusServiceUnavailable, "OpenClaw is not running — start it first via the dashboard or 'solon openclaw'")
 		return
 	}
 

--- a/internal/gateway/ws_proxy.go
+++ b/internal/gateway/ws_proxy.go
@@ -55,6 +55,12 @@ func UIAuthFromCookieOrQuery(next http.Handler) http.Handler {
 	})
 }
 
+// isWebSocketUpgrade returns true when the request is an HTTP→WebSocket upgrade.
+func isWebSocketUpgrade(r *http.Request) bool {
+	return strings.EqualFold(r.Header.Get("Upgrade"), "websocket") &&
+		strings.Contains(strings.ToLower(r.Header.Get("Connection")), "upgrade")
+}
+
 // handleOpenClawWS upgrades an HTTP connection to WebSocket and proxies
 // it bidirectionally to the OpenClaw gateway inside the Docker container.
 // Auth is validated by middleware BEFORE this handler is called.
@@ -62,12 +68,6 @@ func (g *Gateway) handleOpenClawWS(w http.ResponseWriter, r *http.Request) {
 	// Guard: sandbox manager must be available
 	if g.sandboxes == nil {
 		writeError(w, http.StatusServiceUnavailable, "sandbox management not available (Docker not detected)")
-		return
-	}
-
-	// Guard: connection limit
-	if activeWSConns.Load() >= maxWSConnections {
-		writeError(w, http.StatusServiceUnavailable, "too many WebSocket connections")
 		return
 	}
 
@@ -81,6 +81,17 @@ func (g *Gateway) handleOpenClawWS(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	upstreamURL := fmt.Sprintf("ws://%s:%d", containerIP, openclawGatewayPort+1)
+	g.proxyWS(w, r, upstreamURL)
+}
+
+// proxyWS is the shared WebSocket bidirectional-proxy routine used by both
+// the /api/v1/openclaw/ws bridge and the UI reverse proxy's WS upgrades.
+func (g *Gateway) proxyWS(w http.ResponseWriter, r *http.Request, upstreamURL string) {
+	// Guard: connection limit
+	if activeWSConns.Load() >= maxWSConnections {
+		writeError(w, http.StatusServiceUnavailable, "too many WebSocket connections")
+		return
+	}
 
 	// Validate origin (before upgrade)
 	if !g.isAllowedWSOrigin(r) {


### PR DESCRIPTION
## Summary

Follow-up to #57. The UI renders but fails to connect because its WebSocket to \`ws://<host>/api/v1/openclaw/ui\` hits our HTTP handler, which 307-redirects to the trailing-slash form. WebSocket clients don't follow redirects → every attempt closes with 1006.

## Change

- Extract the shared WS proxy body into \`proxyWS(w, r, upstreamURL)\` so it can be reused
- Add \`isWebSocketUpgrade(r)\` helper
- In the UI proxy handler, detect WS upgrades and forward to \`ws://<containerIP>:18789\` **before** the trailing-slash redirect

## Test plan

- [x] WS request to \`/api/v1/openclaw/ui\` no longer returns 307
- [ ] OpenClaw UI successfully connects to its gateway from the dashboard iframe

🤖 Generated with [Claude Code](https://claude.com/claude-code)