### PR TITLE
fix: allow same-origin WS for OpenClaw UI iframe

### DIFF
--- a/internal/gateway/ws_proxy.go
+++ b/internal/gateway/ws_proxy.go
@@ -186,6 +186,15 @@ func (g *Gateway) isAllowedWSOrigin(r *http.Request) bool {
 		return true
 	}
 
+	// Same-origin (the Origin host matches the request Host) — always allow.
+	// This covers the reverse-proxied OpenClaw UI iframe which lives on the
+	// same server as Solon itself.
+	if host := r.Host; host != "" {
+		if strings.HasSuffix(origin, "://"+host) {
+			return true
+		}
+	}
+
 	// Localhost origins always allowed
 	if strings.HasPrefix(origin, "http://localhost") ||
 		strings.HasPrefix(origin, "http://127.0.0.1") ||


### PR DESCRIPTION
## Summary

After #58, WS requests reached the proxy handler but were rejected by \`isAllowedWSOrigin\`. The browser sends \`Origin: http://178.104.104.13:8420\` for the iframe, which didn't match localhost, \`app.getsolon.dev\`, or any tunnel URL.

## Fix

Add a same-origin branch at the top of \`isAllowedWSOrigin\`: if the Origin's host portion matches \`r.Host\`, allow the connection. The browser guarantees this means the WS came from a page loaded from the same server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)