### PR TITLE
fix: disable OpenClaw device auth for reverse-proxied UI

### DIFF
--- a/internal/sandbox/manager.go
+++ b/internal/sandbox/manager.go
@@ -552,7 +552,12 @@ func (m *Manager) EnsureOpenClaw(ctx context.Context, providerKey string) (*Open
 				return nil, fmt.Errorf("installing openclaw: %w", err)
 			}
 
-			openclawCfg := `{"gateway":{"auth":{"mode":"token","token":"solon-openclaw-token"}}}`
+			// dangerouslyDisableDeviceAuth: the OpenClaw control UI normally requires
+			// a browser secure context (HTTPS or localhost) to generate a device
+			// identity. Since Solon reverse-proxies the UI and authenticates users
+			// at the proxy boundary via the Solon API key, we can safely bypass the
+			// device-identity check on the OpenClaw side.
+			openclawCfg := `{"gateway":{"auth":{"mode":"token","token":"solon-openclaw-token"},"controlUi":{"dangerouslyDisableDeviceAuth":true}}}`
 			_, _ = m.docker.containerExec(ctx, tmpID,
 				[]string{"sh", "-c", "mkdir -p /root/.openclaw && printf '%s' '" + openclawCfg + "' > /root/.openclaw/openclaw.json"},
 				nil,
@@ -677,6 +682,10 @@ func (m *Manager) EnsureOpenClaw(ctx context.Context, providerKey string) (*Open
 						"});\n"+
 						"server.listen(PORT, '0.0.0.0', () => console.log('[agent-api] listening on 0.0.0.0:' + PORT));\n"+
 						"API\n"+
+						// Patch existing OpenClaw config (from a previously-built volume)
+						// to set dangerouslyDisableDeviceAuth. New installs already get this
+						// baked in at image build, but pre-existing volumes need upgrading.
+						"node -e \"try{const fs=require('fs');const p='/root/.openclaw/openclaw.json';const c=JSON.parse(fs.readFileSync(p));c.gateway=c.gateway||{};c.gateway.controlUi=c.gateway.controlUi||{};if(!c.gateway.controlUi.dangerouslyDisableDeviceAuth){c.gateway.controlUi.dangerouslyDisableDeviceAuth=true;fs.writeFileSync(p,JSON.stringify(c,null,2));console.log('[solon] patched openclaw controlUi config');}}catch(e){}\" ; "+
 						// Start gateway on loopback (openclaw agent connects locally)
 						// --bind lan: accept connections from the Docker bridge network so Solon
 						// can reverse-proxy the control UI. OpenClaw refuses lan binding without


### PR DESCRIPTION
## Summary

The real underlying reason the OpenClaw UI wouldn't connect (even after #55–#60 fixed the HTTP proxy, WS proxy, origin rewriting, etc.): OpenClaw's client-side JS requires a **browser secure context** (HTTPS or localhost) to derive a device identity, and the gateway rejects WebSocket connections without one. Plain-HTTP public-IP servers don't qualify.

## Fix

Set \`gateway.controlUi.dangerouslyDisableDeviceAuth=true\` in the OpenClaw config. This is an officially-provided break-glass flag for exactly this scenario: a trusted reverse proxy (Solon) that has already authenticated the user at its own boundary.

- Baked into the image-build config for new installs.
- Patched into existing configs on every container start via a small pre-flight node one-liner, so already-deployed volumes upgrade automatically.

## Security reasoning

OpenClaw's device-identity feature is a browser fingerprint that protects direct browser→gateway connections from untrusted clients. In our setup every request passes through Solon first, where the user's API key is validated. Disabling it at the OpenClaw layer doesn't lower the overall security posture.

## Test plan

- [x] Patched config on the live test server, restarted gateway, no more \"control ui requires device identity\" error
- [ ] \`Verbinden\` in the browser successfully opens the WebSocket

🤖 Generated with [Claude Code](https://claude.com/claude-code)