### PR TITLE
fix: pass OpenClaw gateway token in URL fragment

### DIFF
--- a/dashboard/src/pages/instance/OpenClawUI.tsx
+++ b/dashboard/src/pages/instance/OpenClawUI.tsx
@@ -15,12 +15,18 @@ export default function OpenClawUI() {
           // On non-localhost we pass the API key as ?token= so the proxy
           // can authenticate and set a cookie for subsequent asset requests.
           const apiKey = isNonLocalhost() ? getLocalApiKey() : null
-          // Trailing slash matters — the OpenClaw UI uses relative asset paths
-          // (./assets/*) that must resolve under /api/v1/openclaw/ui/ to stay
-          // inside the proxy route prefix.
+          // Two separate tokens in this URL:
+          // - ?token=<api-key>  — Solon's API key for the proxy's cookie auth.
+          //                       Stripped client-side before reaching OpenClaw.
+          // - #token=solon-openclaw-token — OpenClaw's internal gateway token,
+          //                       read by the UI's JS to authenticate the WS.
+          // Trailing slash matters — the UI uses relative asset paths (./assets/*)
+          // that must resolve under /api/v1/openclaw/ui/ to stay inside the proxy
+          // route prefix.
+          const hash = '#token=solon-openclaw-token'
           const url = apiKey
-            ? `/api/v1/openclaw/ui/?token=${encodeURIComponent(apiKey)}`
-            : '/api/v1/openclaw/ui/'
+            ? `/api/v1/openclaw/ui/?token=${encodeURIComponent(apiKey)}${hash}`
+            : `/api/v1/openclaw/ui/${hash}`
           setUiUrl(url)
         } else {
           setError('OpenClaw agent is not running. Start it from the Dashboard first.')


### PR DESCRIPTION
Follow-up to #61. After the device-auth bypass landed, the UI came up but couldn't connect: "unauthorized: gateway token missing". OpenClaw reads its internal gateway token from the URL fragment (`#token=...`); our iframe URL only had `?token=<api-key>` for the Solon proxy's cookie auth. Append `#token=solon-openclaw-token` to the iframe URL so the UI picks up both tokens correctly.