### PR TITLE
chore: weekly OpenClaw auto-bump workflow

### DIFF
--- a/.github/workflows/openclaw-update.yml
+++ b/.github/workflows/openclaw-update.yml
@@ -1,0 +1,96 @@
+name: OpenClaw Version Update
+
+on:
+  schedule:
+    # Mondays 08:00 UTC
+    - cron: '0 8 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read current pinned version
+        id: current
+        run: |
+          VERSION=$(grep -oE 'openclaw@[0-9]+\.[0-9]+\.[0-9]+' internal/sandbox/manager.go | head -1 | cut -d@ -f2)
+          if [ -z "$VERSION" ]; then
+            echo "could not extract pinned version from manager.go" >&2
+            exit 1
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Current pinned: $VERSION"
+
+      - name: Query latest version from npm
+        id: latest
+        run: |
+          VERSION=$(npm view openclaw version)
+          if [ -z "$VERSION" ]; then
+            echo "could not fetch latest openclaw version from npm" >&2
+            exit 1
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Latest on npm: $VERSION"
+
+      - name: Compare versions
+        id: compare
+        run: |
+          if [ "${{ steps.current.outputs.version }}" = "${{ steps.latest.outputs.version }}" ]; then
+            echo "Already on latest. Nothing to do."
+            echo "needs_update=false" >> $GITHUB_OUTPUT
+          else
+            echo "needs_update=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Smoke test new version
+        if: steps.compare.outputs.needs_update == 'true'
+        run: |
+          docker run --rm node:22-slim bash -c "
+            set -e
+            npm install -g openclaw@${{ steps.latest.outputs.version }} >/dev/null 2>&1
+            echo '== openclaw --version =='
+            openclaw --version
+            echo '== openclaw agent --help =='
+            openclaw agent --help >/dev/null
+            echo '== openclaw channels list --json =='
+            openclaw channels list --json >/dev/null
+            echo '== openclaw skills list --json =='
+            openclaw skills list --json >/dev/null
+            echo '== openclaw agents list --json =='
+            openclaw agents list --json >/dev/null
+            echo 'All smoke checks passed.'
+          "
+
+      - name: Bump version in manager.go
+        if: steps.compare.outputs.needs_update == 'true'
+        run: |
+          sed -i "s/openclaw@${{ steps.current.outputs.version }}/openclaw@${{ steps.latest.outputs.version }}/" internal/sandbox/manager.go
+          git diff --stat internal/sandbox/manager.go
+
+      - name: Open pull request
+        if: steps.compare.outputs.needs_update == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: chore/openclaw-${{ steps.latest.outputs.version }}
+          title: "chore: bump OpenClaw to v${{ steps.latest.outputs.version }}"
+          commit-message: "chore: bump OpenClaw to v${{ steps.latest.outputs.version }}"
+          body: |
+            Automated bump from v${{ steps.current.outputs.version }} to v${{ steps.latest.outputs.version }}.
+
+            ## Smoke checks (passed)
+            - `npm install -g openclaw@${{ steps.latest.outputs.version }}` succeeded
+            - `openclaw --version`, `agent --help`, `channels list --json`, `skills list --json`, `agents list --json` all ran without error
+
+            ## Review checklist
+            - [ ] Read the [OpenClaw release notes](https://www.npmjs.com/package/openclaw/v/${{ steps.latest.outputs.version }}) for breaking changes
+            - [ ] Confirm the default model/provider hasn't changed (v2026.4.8 regressed here)
+            - [ ] Deploy to staging and verify chat, channels, and workspace editor still work
+            - [ ] Check that `EnsureOpenClaw` still launches the container cleanly
+
+            This PR was opened by `.github/workflows/openclaw-update.yml`.


### PR DESCRIPTION
## Summary

Scheduled workflow that checks for new OpenClaw releases, runs smoke tests, and opens a PR if the new version works. Solves the \"I don't notice new versions / I don't know if they're safe\" problem that surfaced when OpenClaw flagged v2026.4.11 was available but we're still pinned at v2026.3.24.

## What it does

- Runs every Monday at 08:00 UTC (and on manual dispatch)
- Compares current pin vs latest on npm
- If newer: smoke-tests the new version in a clean Node container (version, CLI help, JSON output for channels/skills/agents)
- On pass: bumps the pinned version and opens a PR with review checklist

## Why not auto-merge?

The v2026.4.8 regression silently changed the default model provider. Human review on the PR stays in the loop to catch that kind of behavioural change, which smoke tests can't reliably detect.

## Test plan

- [x] Smoke test commands pass locally against the currently pinned v2026.3.24
- [ ] First scheduled run lands a PR for v2026.4.11 (or later)

🤖 Generated with [Claude Code](https://claude.com/claude-code)