### PR TITLE
fix: block in-container 'openclaw update' self-upgrade

### DIFF
--- a/internal/sandbox/manager.go
+++ b/internal/sandbox/manager.go
@@ -552,6 +552,27 @@ func (m *Manager) EnsureOpenClaw(ctx context.Context, providerKey string) (*Open
 				return nil, fmt.Errorf("installing openclaw: %w", err)
 			}
 
+			// Install a wrapper that blocks `openclaw update`. Self-updates inside
+			// the container bypass the pinned version in this file, leave the
+			// node_modules in a partially-written state (pi-tools chunks orphaned),
+			// and break the exec tool. Version bumps go through the weekly workflow
+			// at .github/workflows/openclaw-update.yml instead.
+			updateGuard := "#!/bin/sh\n" +
+				"if [ \"$1\" = \"update\" ]; then\n" +
+				"  echo \"[solon] openclaw update is disabled on Solon-managed installs.\" >&2\n" +
+				"  echo \"[solon] Version bumps are handled by .github/workflows/openclaw-update.yml\" >&2\n" +
+				"  exit 1\n" +
+				"fi\n" +
+				"exec /usr/local/bin/openclaw.real \"$@\"\n"
+			_, err = m.docker.containerExec(ctx, tmpID, []string{"sh", "-c",
+				"mv /usr/local/bin/openclaw /usr/local/bin/openclaw.real && " +
+					"cat > /usr/local/bin/openclaw <<'GUARD'\n" + updateGuard + "GUARD\n" +
+					"chmod +x /usr/local/bin/openclaw"}, nil)
+			if err != nil {
+				_ = m.docker.containerRemove(ctx, tmpID)
+				return nil, fmt.Errorf("installing openclaw update guard: %w", err)
+			}
+
 			// dangerouslyDisableDeviceAuth: the OpenClaw control UI normally requires
 			// a browser secure context (HTTPS or localhost) to generate a device
 			// identity. Since Solon reverse-proxies the UI and authenticates users


### PR DESCRIPTION
## Summary

A user-triggered \`openclaw update\` (via the control UI or shell) today silently bumped the container from our pinned v2026.3.24 to v2026.4.11 with a partially-written install — \`pi-embedded-*.js\` referenced a \`pi-tools\` runtime chunk npm hadn't put on disk, so every exec/tool-call returned \`Cannot find module\`.

Fixed the live container manually; this PR prevents the same trap for future containers.

## Change

During image build, after \`npm install -g openclaw@2026.3.24\`, install a small wrapper at \`/usr/local/bin/openclaw\`. It rejects the \`update\` subcommand with a pointer to the automated workflow and delegates everything else to \`openclaw.real\`.

## Test plan

- [x] Wrapper rejects \`openclaw update\` in the live container
- [x] \`openclaw --version\` and agent calls still work
- [x] \`go build\` + \`go vet\` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)