### PR TITLE
fix(dashboard): show real API error instead of "[object Object]"

### DIFF
--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -39,6 +39,22 @@ export function clearToken() {
   localStorage.removeItem(CLOUD_TOKEN_KEY)
 }
 
+function extractErrorMessage(body: unknown, fallback: string): string {
+  if (body && typeof body === 'object') {
+    const err = (body as { error?: unknown }).error
+    if (typeof err === 'string') return err
+    if (err && typeof err === 'object') {
+      const msg = (err as { message?: unknown }).message
+      if (typeof msg === 'string') return msg
+      try { return JSON.stringify(err) } catch { /* fall through */ }
+    }
+    const topMsg = (body as { message?: unknown }).message
+    if (typeof topMsg === 'string') return topMsg
+  }
+  if (typeof body === 'string' && body) return body
+  return fallback
+}
+
 export async function fetchJSON<T>(url: string, opts?: RequestInit): Promise<T> {
   const apiKey = isNonLocalhost() ? getLocalApiKey() : null
   const res = await fetch(url, {
@@ -50,8 +66,8 @@ export async function fetchJSON<T>(url: string, opts?: RequestInit): Promise<T> 
     },
   })
   if (!res.ok) {
-    const err = await res.json().catch(() => ({ error: { message: res.statusText } }))
-    throw new Error(err.error?.message || err.error || res.statusText)
+    const body = await res.json().catch(() => null)
+    throw new Error(extractErrorMessage(body, `HTTP ${res.status} ${res.statusText}`.trim()))
   }
   return res.json()
 }
@@ -116,8 +132,8 @@ export async function cloudFetch<T>(path: string, opts?: RequestInit): Promise<T
   }
 
   if (!res.ok) {
-    const err = await res.json().catch(() => ({ error: res.statusText }))
-    throw new Error(err.error || res.statusText)
+    const body = await res.json().catch(() => null)
+    throw new Error(extractErrorMessage(body, `HTTP ${res.status} ${res.statusText}`.trim()))
   }
 
   return res.json()


### PR DESCRIPTION
## Summary
- `fetchJSON` and `cloudFetch` threw `new Error(err.error || ...)`. When the API returned `{ error: { ... } }` with an object payload, the Error constructor coerced the object to the literal string `"[object Object]"`, which then rendered in the dashboard (e.g. on the Home "Start your Agent" card when Launch Agent failed).
- Added a shared `extractErrorMessage` helper that handles every shape we've seen (`string`, `{error: string}`, `{error: {message}}`, top-level `{message}`, raw string bodies) and falls back to `HTTP <status> <statusText>` so the user always sees something actionable.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `npm run build` succeeds
- [ ] Trigger a failing `/api/v1/openclaw/start` (daemon offline) — confirm the red error text now shows the real HTTP status / server message instead of `[object Object]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)