### PR TITLE
refactor(dashboard): reuse extractErrorMessage across all fetch callers

### DIFF
--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -39,7 +39,7 @@ export function clearToken() {
   localStorage.removeItem(CLOUD_TOKEN_KEY)
 }
 
-function extractErrorMessage(body: unknown, fallback: string): string {
+export function extractErrorMessage(body: unknown, fallback: string): string {
   if (body && typeof body === 'object') {
     const err = (body as { error?: unknown }).error
     if (typeof err === 'string') return err
@@ -55,6 +55,11 @@ function extractErrorMessage(body: unknown, fallback: string): string {
   return fallback
 }
 
+export async function errorFromResponse(res: Response): Promise<Error> {
+  const body = await res.json().catch(() => null)
+  return new Error(extractErrorMessage(body, `HTTP ${res.status} ${res.statusText}`.trim()))
+}
+
 export async function fetchJSON<T>(url: string, opts?: RequestInit): Promise<T> {
   const apiKey = isNonLocalhost() ? getLocalApiKey() : null
   const res = await fetch(url, {
@@ -65,10 +70,7 @@ export async function fetchJSON<T>(url: string, opts?: RequestInit): Promise<T> 
       ...opts?.headers,
     },
   })
-  if (!res.ok) {
-    const body = await res.json().catch(() => null)
-    throw new Error(extractErrorMessage(body, `HTTP ${res.status} ${res.statusText}`.trim()))
-  }
+  if (!res.ok) throw await errorFromResponse(res)
   return res.json()
 }
 
@@ -131,10 +133,7 @@ export async function cloudFetch<T>(path: string, opts?: RequestInit): Promise<T
     throw new Error('Unauthorized')
   }
 
-  if (!res.ok) {
-    const body = await res.json().catch(() => null)
-    throw new Error(extractErrorMessage(body, `HTTP ${res.status} ${res.statusText}`.trim()))
-  }
+  if (!res.ok) throw await errorFromResponse(res)
 
   return res.json()
 }

--- a/dashboard/src/api/local.ts
+++ b/dashboard/src/api/local.ts
@@ -1,4 +1,4 @@
-import { fetchJSON, getLocalApiKey, isNonLocalhost } from './client'
+import { extractErrorMessage, fetchJSON, getLocalApiKey, isNonLocalhost } from './client'
 import type { InstanceAPI, HealthStatus, SystemInfo, ModelInfo, APIKey, RequestLogEntry, UsageStats, KeyUsage, TunnelStatus, RemoteStatus, CatalogModel, DownloadProgress, CreateKeyOptions, ProviderConfig, SandboxInfo, SandboxPreset, SandboxStats, SandboxTier } from './types'
 
 // Local instance API — same-origin calls, no auth headers needed
@@ -125,8 +125,8 @@ export function pullModel(name: string, callbacks: PullModelCallbacks): AbortCon
       })
 
       if (!res.ok) {
-        const err = await res.json().catch(() => ({ error: { message: res.statusText } }))
-        callbacks.onError(err.error?.message || res.statusText)
+        const body = await res.json().catch(() => null)
+        callbacks.onError(extractErrorMessage(body, `HTTP ${res.status} ${res.statusText}`.trim()))
         return
       }
 

--- a/dashboard/src/pages/Home.tsx
+++ b/dashboard/src/pages/Home.tsx
@@ -4,7 +4,7 @@ import { useModeStore } from '../store/mode'
 import { useServerStore } from '../store/server'
 import { useAuthStore } from '../store/auth'
 import Card from '../components/Card'
-import { fetchJSON, getLocalApiKey, isNonLocalhost } from '../api/client'
+import { errorFromResponse, fetchJSON, getLocalApiKey, isNonLocalhost } from '../api/client'
 import type { UsageStats } from '../api/types'
 
 function authHeaders(): Record<string, string> {
@@ -107,7 +107,7 @@ export default function Home() {
         headers: { 'Content-Type': 'application/json', ...authHeaders() },
         body: JSON.stringify({ message: msg }),
       })
-      if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+      if (!resp.ok) throw await errorFromResponse(resp)
       const data = await resp.json() as Record<string, unknown>
       const result = data.result as Record<string, unknown> | undefined
       const payloads = result?.payloads as { text?: string }[] | undefined

--- a/dashboard/src/pages/instance/AgentSettings.tsx
+++ b/dashboard/src/pages/instance/AgentSettings.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
-import { fetchJSON, getLocalApiKey, isNonLocalhost } from '../../api/client'
+import { errorFromResponse, fetchJSON, getLocalApiKey, isNonLocalhost } from '../../api/client'
 import Card from '../../components/Card'
 
 function authHeaders(): Record<string, string> {
@@ -140,11 +140,7 @@ export default function AgentSettings() {
         headers: { 'Content-Type': 'application/json', ...authHeaders() },
         body: JSON.stringify({ channel: 'telegram', bot_token: botToken.trim() }),
       })
-      if (!res.ok) {
-        const err = await res.json().catch(() => ({ error: res.statusText })) as Record<string, unknown>
-        const msg = typeof err.error === 'string' ? err.error : (err.error as Record<string, unknown>)?.message as string || res.statusText
-        throw new Error(msg)
-      }
+      if (!res.ok) throw await errorFromResponse(res)
       setBotToken('')
       setShowTelegramForm(false)
       setConnectSuccess('Channel added. Check the status above — the gateway may need a moment to connect.')

--- a/dashboard/src/pages/instance/Chat.tsx
+++ b/dashboard/src/pages/instance/Chat.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
-import { fetchJSON, getLocalApiKey, isNonLocalhost } from '../../api/client'
+import { errorFromResponse, fetchJSON, getLocalApiKey, isNonLocalhost } from '../../api/client'
 import type { ModelInfo } from '../../api/types'
 
 function authHeaders(): Record<string, string> {
@@ -100,10 +100,7 @@ export default function Chat() {
     setError('')
     try {
       await fetch('/api/v1/openclaw/start', { method: 'POST', headers: authHeaders() }).then(async r => {
-        if (!r.ok) {
-          const err = await r.json().catch(() => ({ error: r.statusText })) as { error?: string }
-          throw new Error(err.error || `HTTP ${r.status}`)
-        }
+        if (!r.ok) throw await errorFromResponse(r)
       })
       // Wait briefly for container to be ready, then reconnect
       await new Promise(resolve => setTimeout(resolve, 3000))
@@ -147,10 +144,7 @@ export default function Chat() {
         headers: { 'Content-Type': 'application/json', ...authHeaders() },
         body: JSON.stringify({ message: text, agent: selectedAgent, thinking: thinkingLevel }),
       })
-      if (!resp.ok) {
-        const err = await resp.json().catch(() => ({ error: { message: resp.statusText } }))
-        throw new Error((err as { error?: { message?: string } }).error?.message || `HTTP ${resp.status}`)
-      }
+      if (!resp.ok) throw await errorFromResponse(resp)
 
       const contentType = resp.headers.get('content-type') ?? ''
       if (contentType.includes('text/event-stream') && resp.body) {
@@ -225,10 +219,7 @@ export default function Chat() {
         headers: { 'Content-Type': 'application/json', ...authHeaders() },
         body: JSON.stringify({ model: selectedModel, messages: allMsgs, stream: true }),
       })
-      if (!response.ok) {
-        const err = await response.json().catch(() => ({ error: { message: response.statusText } }))
-        throw new Error((err as { error?: { message?: string } }).error?.message || `HTTP ${response.status}`)
-      }
+      if (!response.ok) throw await errorFromResponse(response)
 
       const reader = response.body?.getReader()
       if (!reader) throw new Error('No response body')

--- a/dashboard/src/pages/instance/Setup.tsx
+++ b/dashboard/src/pages/instance/Setup.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import type { ProviderConfig, SandboxPreset } from '../../api/types'
 import { providerAPI, sandboxAPI } from '../../api/local'
+import { errorFromResponse } from '../../api/client'
 
 const STEPS = ['welcome', 'provider', 'test', 'sandbox', 'done'] as const
 type Step = (typeof STEPS)[number]
@@ -69,10 +70,7 @@ export default function Setup({ onComplete }: SetupProps) {
           max_tokens: 10,
         }),
       })
-      if (!resp.ok) {
-        const data = await resp.json().catch(() => ({ error: { message: resp.statusText } }))
-        throw new Error((data as { error?: { message?: string } }).error?.message || `HTTP ${resp.status}`)
-      }
+      if (!resp.ok) throw await errorFromResponse(resp)
       const data = await resp.json() as { choices?: { message?: { content?: string } }[] }
       const reply = data.choices?.[0]?.message?.content || 'OK'
       setTestResult(reply)


### PR DESCRIPTION
## Summary
Follow-up to #66 (now merged). Seven call sites in the dashboard were hand-rolling the same `err.error?.message || res.statusText` extraction, five of which had the identical latent `[object Object]` coercion bug that #66 fixed inside `fetchJSON`/`cloudFetch`.

Changes:
- Export `extractErrorMessage` from `client.ts`.
- Add `errorFromResponse(res)` helper — `res.json().catch(() => null) + extractErrorMessage(..., HTTP <status> <statusText>)` in one line.
- Collapse all seven call sites to `if (!res.ok) throw await errorFromResponse(res)`.
- Use the same helper inside `fetchJSON`/`cloudFetch`.

Net **-16 lines**, consistent error shape across the dashboard.

_(Originally opened as #67 stacked on #66; GitHub auto-closed it when #66's base branch was deleted on merge. Rebased onto master and re-opened — same commit content, new PR number.)_

## Call sites touched
- `src/api/client.ts` (`fetchJSON`, `cloudFetch`)
- `src/api/local.ts` (`pullModel` SSE error)
- `src/pages/Home.tsx` (`handleQuickSend`)
- `src/pages/instance/Setup.tsx` (provider test)
- `src/pages/instance/AgentSettings.tsx` (`handleConnect`)
- `src/pages/instance/Chat.tsx` (`handleStartAgent`, `sendViaAgent`, `sendViaSSE`)

## Test plan
- [x] `tsc --noEmit` clean
- [x] `npm run build` succeeds (gzip slightly smaller)
- [ ] Manually trigger a failing call at each site — confirm real server message surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)