### PR TITLE
fix(models): pull only the requested quant for GGUF repos

### DIFF
--- a/internal/models/download.go
+++ b/internal/models/download.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -225,8 +226,15 @@ func DownloadModel(ctx context.Context, repo, fileFilter, blobsDir string, progr
 	// On any ambiguity (zero or multiple matches, network failure) we fall back
 	// to the library path below, preserving previous behavior.
 	if fileFilter != "" {
-		if url, err := resolveGGUFURL(ctx, repo, fileFilter); err == nil {
-			return DownloadFromURL(ctx, url, blobsDir, progressFn)
+		if fileURL, err := resolveGGUFURL(ctx, repo, fileFilter); err == nil {
+			return DownloadFromURL(ctx, fileURL, blobsDir, progressFn)
+		} else if progressFn != nil {
+			// Fallback to the repo scan can pull every quant in the repo, so
+			// make the reason visible rather than failing over silently.
+			progressFn(DownloadProgress{
+				Event:   "progress",
+				Message: fmt.Sprintf("could not resolve a single %q file (%v); scanning full repo", fileFilter, err),
+			})
 		}
 	}
 
@@ -357,7 +365,8 @@ type hfTreeNode struct {
 // It returns an error when zero or more than one file matches, so the caller
 // can fall back to the multi-file downloader.
 func resolveGGUFURL(ctx context.Context, repo, quant string) (string, error) {
-	treeURL := fmt.Sprintf("%s/api/models/%s/tree/main", hfBaseURL, repo)
+	// recursive=1 so quants nested in per-quant subdirectories are also listed.
+	treeURL := fmt.Sprintf("%s/api/models/%s/tree/main?recursive=1", hfBaseURL, escapePath(repo))
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, treeURL, nil)
 	if err != nil {
 		return "", err
@@ -386,7 +395,18 @@ func resolveGGUFURL(ctx context.Context, repo, quant string) (string, error) {
 	if !ok {
 		return "", fmt.Errorf("no unique .gguf file for quant %q in %s", quant, repo)
 	}
-	return fmt.Sprintf("%s/%s/resolve/main/%s", hfBaseURL, repo, match), nil
+	return fmt.Sprintf("%s/%s/resolve/main/%s", hfBaseURL, escapePath(repo), escapePath(match)), nil
+}
+
+// escapePath percent-escapes each segment of a slash-separated path, leaving
+// the separators literal — HuggingFace requires literal slashes in repo ids
+// and nested file paths.
+func escapePath(p string) string {
+	segs := strings.Split(p, "/")
+	for i, s := range segs {
+		segs[i] = url.PathEscape(s)
+	}
+	return strings.Join(segs, "/")
 }
 
 // selectGGUFByQuant picks the single .gguf path whose filename matches quant.

--- a/internal/models/download.go
+++ b/internal/models/download.go
@@ -3,6 +3,7 @@ package models
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -215,6 +216,20 @@ func downloadWithResume(ctx context.Context, url, filename, tmpPath, blobsDir st
 
 // DownloadModel downloads a GGUF model from HuggingFace.
 func DownloadModel(ctx context.Context, repo, fileFilter, blobsDir string, progressFn func(DownloadProgress)) (*DownloadResult, error) {
+	// Fast path: when a quantization filter is given, resolve the exact .gguf
+	// file via the HF tree API and fetch just that one file by direct URL. The
+	// hfdownloader library only applies its filename filter to nodes it detects
+	// as LFS, and that detection is unreliable for some GGUF repos — when it
+	// fails the library downloads every quant in the repo (and findGGUF then
+	// keeps an arbitrary one). Resolving the single file ourselves avoids that.
+	// On any ambiguity (zero or multiple matches, network failure) we fall back
+	// to the library path below, preserving previous behavior.
+	if fileFilter != "" {
+		if url, err := resolveGGUFURL(ctx, repo, fileFilter); err == nil {
+			return DownloadFromURL(ctx, url, blobsDir, progressFn)
+		}
+	}
+
 	// Use a temp dir for download, then move to blobs
 	tmpDir, err := os.MkdirTemp(blobsDir, "download-*")
 	if err != nil {
@@ -325,6 +340,80 @@ func DownloadModel(ctx context.Context, repo, fileFilter, blobsDir string, progr
 		Size:     info.Size(),
 		SHA256:   hash,
 	}, nil
+}
+
+// hfBaseURL is the HuggingFace base URL. It is a variable so tests can point
+// the tree/resolve calls at a local server.
+var hfBaseURL = "https://huggingface.co"
+
+// hfTreeNode is the subset of the HuggingFace tree API response we need.
+type hfTreeNode struct {
+	Type string `json:"type"`
+	Path string `json:"path"`
+}
+
+// resolveGGUFURL queries the HuggingFace tree API for repo and returns the
+// direct resolve URL of the single .gguf file matching quant (e.g. "Q8_0").
+// It returns an error when zero or more than one file matches, so the caller
+// can fall back to the multi-file downloader.
+func resolveGGUFURL(ctx context.Context, repo, quant string) (string, error) {
+	treeURL := fmt.Sprintf("%s/api/models/%s/tree/main", hfBaseURL, repo)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, treeURL, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("tree API for %s returned %s", repo, resp.Status)
+	}
+
+	var nodes []hfTreeNode
+	if err := json.NewDecoder(resp.Body).Decode(&nodes); err != nil {
+		return "", err
+	}
+	paths := make([]string, 0, len(nodes))
+	for _, n := range nodes {
+		if n.Type == "file" {
+			paths = append(paths, n.Path)
+		}
+	}
+
+	match, ok := selectGGUFByQuant(paths, quant)
+	if !ok {
+		return "", fmt.Errorf("no unique .gguf file for quant %q in %s", quant, repo)
+	}
+	return fmt.Sprintf("%s/%s/resolve/main/%s", hfBaseURL, repo, match), nil
+}
+
+// selectGGUFByQuant picks the single .gguf path whose filename matches quant.
+// Matching is case-insensitive and substring-based; if several files contain
+// the quant token it narrows to those whose name (minus extension) ends with
+// it. It returns ok=false unless exactly one file matches, signalling the
+// caller to fall back rather than guess (e.g. split or multi-part GGUFs).
+func selectGGUFByQuant(paths []string, quant string) (string, bool) {
+	q := strings.ToLower(quant)
+	var contains, suffix []string
+	for _, p := range paths {
+		base := strings.ToLower(filepath.Base(p))
+		if !strings.HasSuffix(base, ".gguf") || !strings.Contains(base, q) {
+			continue
+		}
+		contains = append(contains, p)
+		if strings.HasSuffix(strings.TrimSuffix(base, ".gguf"), q) {
+			suffix = append(suffix, p)
+		}
+	}
+	if len(suffix) == 1 {
+		return suffix[0], true
+	}
+	if len(contains) == 1 {
+		return contains[0], true
+	}
+	return "", false
 }
 
 // findGGUF recursively searches for a .gguf file in the given directory.

--- a/internal/models/download_test.go
+++ b/internal/models/download_test.go
@@ -58,11 +58,14 @@ func TestResolveGGUFURL(t *testing.T) {
 	const repo = "Qwen/Qwen3-Embedding-8B-GGUF"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/api/models/"+repo+"/tree/main", r.URL.Path)
+		// Must request a recursive listing so nested quants are surfaced.
+		assert.Equal(t, "1", r.URL.Query().Get("recursive"))
 		_, _ = fmt.Fprint(w, `[
 			{"type":"file","path":".gitattributes"},
 			{"type":"directory","path":"sub"},
 			{"type":"file","path":"Qwen3-Embedding-8B-Q4_K_M.gguf"},
-			{"type":"file","path":"Qwen3-Embedding-8B-Q8_0.gguf"}
+			{"type":"file","path":"Qwen3-Embedding-8B-Q8_0.gguf"},
+			{"type":"file","path":"nested/Qwen3-Embedding-8B-Q6_K.gguf"}
 		]`)
 	}))
 	defer srv.Close()
@@ -75,7 +78,12 @@ func TestResolveGGUFURL(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, srv.URL+"/"+repo+"/resolve/main/Qwen3-Embedding-8B-Q8_0.gguf", url)
 
-	// Ambiguous quant present in two distinct files -> error, caller falls back.
+	// A quant that lives in a subdirectory resolves to its nested path.
+	url, err = resolveGGUFURL(context.Background(), repo, "Q6_K")
+	require.NoError(t, err)
+	assert.Equal(t, srv.URL+"/"+repo+"/resolve/main/nested/Qwen3-Embedding-8B-Q6_K.gguf", url)
+
+	// Ambiguous quant present in several distinct files -> error, caller falls back.
 	_, err = resolveGGUFURL(context.Background(), repo, "Q")
 	assert.Error(t, err)
 }

--- a/internal/models/download_test.go
+++ b/internal/models/download_test.go
@@ -1,0 +1,81 @@
+package models
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSelectGGUFByQuant(t *testing.T) {
+	// The full quant set published by Qwen/Qwen3-Embedding-8B-GGUF, which
+	// previously caused every file to download because the library's filter
+	// was skipped. Each quant must resolve to exactly its own file.
+	qwen := []string{
+		".gitattributes",
+		"README.md",
+		"Qwen3-Embedding-8B-Q4_K_M.gguf",
+		"Qwen3-Embedding-8B-Q5_0.gguf",
+		"Qwen3-Embedding-8B-Q5_K_M.gguf",
+		"Qwen3-Embedding-8B-Q6_K.gguf",
+		"Qwen3-Embedding-8B-Q8_0.gguf",
+		"Qwen3-Embedding-8B-f16.gguf",
+	}
+
+	tests := []struct {
+		name  string
+		paths []string
+		quant string
+		want  string
+		ok    bool
+	}{
+		{name: "Q8_0 picks only Q8_0", paths: qwen, quant: "Q8_0", want: "Qwen3-Embedding-8B-Q8_0.gguf", ok: true},
+		{name: "Q5_0 not confused with Q5_K_M", paths: qwen, quant: "Q5_0", want: "Qwen3-Embedding-8B-Q5_0.gguf", ok: true},
+		{name: "Q5_K_M exact", paths: qwen, quant: "Q5_K_M", want: "Qwen3-Embedding-8B-Q5_K_M.gguf", ok: true},
+		{name: "case-insensitive", paths: qwen, quant: "q6_k", want: "Qwen3-Embedding-8B-Q6_K.gguf", ok: true},
+		{name: "f16 lowercase suffix", paths: qwen, quant: "f16", want: "Qwen3-Embedding-8B-f16.gguf", ok: true},
+		{name: "resolves in subdir", paths: []string{"gguf/model-Q8_0.gguf"}, quant: "Q8_0", want: "gguf/model-Q8_0.gguf", ok: true},
+		{name: "no match returns false", paths: qwen, quant: "Q3_K_S", want: "", ok: false},
+		{name: "non-gguf ignored", paths: []string{"config-Q8_0.json"}, quant: "Q8_0", want: "", ok: false},
+		{name: "ambiguous split falls back", paths: []string{"m-Q8_0-00001-of-00002.gguf", "m-Q8_0-00002-of-00002.gguf"}, quant: "Q8_0", want: "", ok: false},
+		{name: "empty list", paths: nil, quant: "Q8_0", want: "", ok: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := selectGGUFByQuant(tt.paths, tt.quant)
+			assert.Equal(t, tt.ok, ok)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestResolveGGUFURL(t *testing.T) {
+	const repo = "Qwen/Qwen3-Embedding-8B-GGUF"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/models/"+repo+"/tree/main", r.URL.Path)
+		_, _ = fmt.Fprint(w, `[
+			{"type":"file","path":".gitattributes"},
+			{"type":"directory","path":"sub"},
+			{"type":"file","path":"Qwen3-Embedding-8B-Q4_K_M.gguf"},
+			{"type":"file","path":"Qwen3-Embedding-8B-Q8_0.gguf"}
+		]`)
+	}))
+	defer srv.Close()
+
+	orig := hfBaseURL
+	hfBaseURL = srv.URL
+	t.Cleanup(func() { hfBaseURL = orig })
+
+	url, err := resolveGGUFURL(context.Background(), repo, "Q8_0")
+	require.NoError(t, err)
+	assert.Equal(t, srv.URL+"/"+repo+"/resolve/main/Qwen3-Embedding-8B-Q8_0.gguf", url)
+
+	// Ambiguous quant present in two distinct files -> error, caller falls back.
+	_, err = resolveGGUFURL(context.Background(), repo, "Q")
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Summary

`DownloadModel` passed the requested quantization to the `hfdownloader` library as a filename filter, but that library only applies its filter to repo nodes it detects as **LFS**. That detection is unreliable for some GGUF repos (e.g. `Qwen/Qwen3-Embedding-8B-GGUF`), so the filter was silently ignored and **every quant in the repo** was downloaded (~44 GB for that repo). `findGGUF` then registered an arbitrary one (the last `.gguf` by walk order — `f16`).

This change adds a fast path: when a quant filter is given, resolve the **exact** `.gguf` filename via the HuggingFace tree API and fetch just that file through the existing `DownloadFromURL` (resume + retry + sha256 blob naming). On any ambiguity — zero/multiple matches or a network/API error — it falls back to the previous library path, so existing behavior is preserved.

### Changes
- `internal/models/download.go`
  - `DownloadModel`: try `resolveGGUFURL` + `DownloadFromURL` when a quant filter is set; fall back to the library path otherwise.
  - `resolveGGUFURL`: queries `GET /api/models/<repo>/tree/main`, collects file nodes, selects the match.
  - `selectGGUFByQuant`: pure, case-insensitive matcher; narrows to a trailing-token match when several files contain the quant; returns `ok=false` (→ fallback) unless exactly one file matches.
  - `hfBaseURL` package var so tests can target a local server.
- `internal/models/download_test.go` (new): table-driven tests for the matcher + an httptest-backed resolver test.

## Test plan
- [x] `go build ./internal/...`
- [x] `go vet ./internal/models/`
- [x] `go test ./internal/models/` (matcher cases incl. Q5_0-vs-Q5_K_M, subdir, split-file fallback, case-insensitive; resolver happy-path + ambiguous-quant error)
- [ ] Manual: `solon models pull "Qwen/Qwen3-Embedding-8B-GGUF:Q8_0"` downloads only the 8.0 GB Q8_0 file (requires rebuilt binary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)