### PR TITLE
fix(embeddings): report prompt token count for native backend

### DIFF
--- a/internal/inference/backends/llamacpp.go
+++ b/internal/inference/backends/llamacpp.go
@@ -163,6 +163,7 @@ func (l *LlamaCpp) Embeddings(ctx context.Context, req *EmbeddingRequest) (*Embe
 		return &EmbeddingResponse{
 			Embeddings: [][]float64{float32sToFloat64s(emb)},
 			Model:      req.Model,
+			TokenCount: countTokens(embCtx, req.Input),
 		}, nil
 	}
 
@@ -179,7 +180,23 @@ func (l *LlamaCpp) Embeddings(ctx context.Context, req *EmbeddingRequest) (*Embe
 	return &EmbeddingResponse{
 		Embeddings: result,
 		Model:      req.Model,
+		TokenCount: countTokens(embCtx, req.Input),
 	}, nil
+}
+
+// countTokens returns the total token count across inputs, best-effort. Token
+// counting must never fail an otherwise-successful embedding request, so an
+// input that fails to tokenize simply contributes zero.
+func countTokens(ctx *llama.Context, inputs []string) int {
+	total := 0
+	for _, s := range inputs {
+		toks, err := ctx.Tokenize(s)
+		if err != nil {
+			continue
+		}
+		total += len(toks)
+	}
+	return total
 }
 
 // ensureModel ensures the requested model is loaded. Must be called with mu held.


### PR DESCRIPTION
## Summary

The native llama.cpp embeddings path (`internal/inference/backends/llamacpp.go`) never set `TokenCount` on its `EmbeddingResponse`. The engine maps that field into `usage.prompt_tokens`/`total_tokens`, so every `/v1/embeddings` response reported `usage {prompt_tokens: 0, total_tokens: 0}`, and `store.LogRequest` recorded zero tokens for all embedding calls (skewing per-key usage analytics).

This counts tokens with the model tokenizer (`Context.Tokenize`) and returns the total. Counting is best-effort: an input that fails to tokenize contributes zero and never fails an otherwise-successful embedding request.

### Changes
- `internal/inference/backends/llamacpp.go`: set `TokenCount` on both the single-input and batch return paths; add a `countTokens` helper.

## Test plan
- [x] `make build` (compiles the cgo `llamacpp` path)
- [ ] Manual: `POST /v1/embeddings` now returns non-zero `usage.prompt_tokens` matching the tokenized input length

🤖 Generated with [Claude Code](https://claude.com/claude-code)